### PR TITLE
Fix docs sidebar/TOC alignment and add tabbed mobile navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ yarn-error.log*
 .claude/
 .codex/
 .agents/plans/
+.agents/prototypes/
 
 # Testing
 nginx/

--- a/src/components/MarketingHeader/HandbookNavTree.tsx
+++ b/src/components/MarketingHeader/HandbookNavTree.tsx
@@ -1,0 +1,151 @@
+import React, { useMemo, useState } from 'react';
+import { isActiveSidebarItem } from '@docusaurus/plugin-content-docs/client';
+import type {
+  PropSidebar,
+  PropSidebarItem,
+  PropSidebarItemCategory,
+} from '@docusaurus/plugin-content-docs';
+
+type Props = {
+  sidebar: PropSidebar;
+  activePath: string;
+  onNavigate?: () => void;
+};
+
+function isCategory(
+  item: PropSidebarItem
+): item is PropSidebarItemCategory {
+  return item.type === 'category';
+}
+
+function sidebarItemKey(item: PropSidebarItem, index: number): string {
+  if (item.type === 'category') return item.label;
+  if (item.type === 'link') return item.href;
+  return `html-${index}`;
+}
+
+function CategoryItem({
+  category,
+  activePath,
+  onNavigate,
+}: {
+  category: PropSidebarItemCategory;
+  activePath: string;
+  onNavigate?: () => void;
+}): JSX.Element {
+  const [expanded, setExpanded] = useState(
+    () => !category.collapsed || isActiveSidebarItem(category, activePath)
+  );
+
+  return (
+    <div className={`mh-toc-category${expanded ? ' expanded' : ''}`}>
+      <button
+        type="button"
+        className="mh-toc-category-header"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+      >
+        <span>{category.label}</span>
+        <svg className="mh-chevron" viewBox="0 0 7 7" fill="none" aria-hidden="true">
+          <path d="M0.5 3L3.5 6L6.5 3" stroke="currentColor" />
+        </svg>
+      </button>
+      <div className="mh-toc-category-items">
+        {category.items.map((item, index) => (
+          <SidebarItem
+            key={sidebarItemKey(item, index)}
+            item={item}
+            activePath={activePath}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SidebarItem({
+  item,
+  activePath,
+  onNavigate,
+}: {
+  item: PropSidebarItem;
+  activePath: string;
+  onNavigate?: () => void;
+}): JSX.Element | null {
+  if (isCategory(item)) {
+    return (
+      <CategoryItem
+        category={item}
+        activePath={activePath}
+        onNavigate={onNavigate}
+      />
+    );
+  }
+
+  if (item.type === 'link') {
+    const current = isActiveSidebarItem(item, activePath);
+    return (
+      <a
+        className={`mh-toc-article${current ? ' current' : ''}`}
+        href={item.href}
+        onClick={onNavigate}
+      >
+        {item.label}
+      </a>
+    );
+  }
+
+  return null;
+}
+
+export default function HandbookNavTree({
+  sidebar,
+  activePath,
+  onNavigate,
+}: Props): JSX.Element {
+  const { topLinks, categories } = useMemo(() => {
+    const links: PropSidebarItem[] = [];
+    const cats: PropSidebarItemCategory[] = [];
+    sidebar.forEach((item) => {
+      if (isCategory(item)) {
+        cats.push(item);
+      } else if (item.type === 'link' && item.className !== 'hidden') {
+        // Docusaurus auto-adds a second, intentionally hidden link to the
+        // intro doc alongside the configured "Welcome" link; skip it here
+        // the same way the default sidebar hides it via CSS.
+        links.push(item);
+      }
+    });
+    return { topLinks: links, categories: cats };
+  }, [sidebar]);
+
+  if (sidebar.length === 0) {
+    return <p className="mh-toc-empty">No handbook chapters found.</p>;
+  }
+
+  return (
+    <div>
+      {topLinks.map((item) =>
+        item.type === 'link' ? (
+          <a
+            key={item.href}
+            className={`mh-toc-welcome${isActiveSidebarItem(item, activePath) ? ' current' : ''}`}
+            href={item.href}
+            onClick={onNavigate}
+          >
+            {item.label}
+          </a>
+        ) : null
+      )}
+      {categories.map((category) => (
+        <CategoryItem
+          key={category.label}
+          category={category}
+          activePath={activePath}
+          onNavigate={onNavigate}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/MarketingHeader/MarketingHeader.tsx
+++ b/src/components/MarketingHeader/MarketingHeader.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import type { PropSidebar } from '@docusaurus/plugin-content-docs';
 import {
   marketingHeaderCtas,
   marketingHeaderItems,
@@ -13,14 +14,33 @@ import {
   type MarketingHeaderMenu,
 } from './marketingHeaderData';
 import { marketingHeaderIcons } from './marketingHeaderIcons';
+import HandbookNavTree from './HandbookNavTree';
 
 type Props = {
   shadowRoot: ShadowRoot;
+  handbookSidebar?: PropSidebar;
+  activePath?: string;
 };
 
-export default function MarketingHeader({ shadowRoot }: Props): JSX.Element {
+type MobileTab = 'handbook' | 'modular';
+
+export default function MarketingHeader({
+  shadowRoot,
+  handbookSidebar,
+  activePath,
+}: Props): JSX.Element {
   const [openMenu, setOpenMenu] = useState<string | null>(null);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const hasHandbookTab = Boolean(handbookSidebar && handbookSidebar.length > 0);
+  // `handbookSidebar` arrives asynchronously from the outer root (see
+  // MarketingHeaderHost) — it's undefined on the very first render, even on
+  // doc pages. Rather than storing the *displayed* tab directly in state
+  // (which would race with that first render and permanently lock onto
+  // "modular"), we store only the user's explicit choice, if any, and fall
+  // back to "handbook" whenever it's available and the user hasn't chosen
+  // otherwise. This keeps tab selection correct regardless of data timing.
+  const [userSelectedTab, setUserSelectedTab] = useState<MobileTab | null>(null);
+  const mobileTab: MobileTab = userSelectedTab ?? (hasHandbookTab ? 'handbook' : 'modular');
   const navId = useId();
   const headerRef = useRef<HTMLElement | null>(null);
 
@@ -121,33 +141,95 @@ export default function MarketingHeader({ shadowRoot }: Props): JSX.Element {
       </nav>
 
       <div
+        className="mh-mobile-backdrop"
+        hidden={!mobileOpen}
+        aria-hidden="true"
+        onClick={() => setMobileOpen(false)}
+      />
+
+      <div
         id={`${navId}-mobile-menu`}
         className="mh-mobile-menu"
         hidden={!mobileOpen}
       >
-        <ul className="mh-mobile-list" role="list">
-          {marketingHeaderItems.map((item) => (
-            <li key={item.type === 'link' ? item.label : item.menu.label}>
-              {item.type === 'link' ? (
-                <a className="mh-mobile-top-link" href={item.href}>
-                  {item.label}
-                </a>
-              ) : (
-                <MobileMenuGroup menu={item.menu} />
-              )}
-            </li>
-          ))}
-        </ul>
-        <div className="mh-mobile-actions">
-          <a
-            className="mh-secondary-cta"
-            href={marketingHeaderCtas.secondary.href}
+        {hasHandbookTab ? (
+          <div className="mh-tab-track" role="tablist" aria-label="Mobile navigation">
+            <span
+              className="mh-tab-pill"
+              style={{
+                transform: `translateX(${mobileTab === 'handbook' ? '0%' : '100%'})`,
+              }}
+              aria-hidden="true"
+            />
+            <button
+              type="button"
+              className="mh-tab-btn"
+              role="tab"
+              aria-selected={mobileTab === 'handbook'}
+              onClick={() => setUserSelectedTab('handbook')}
+            >
+              Inference Handbook
+            </button>
+            <button
+              type="button"
+              className="mh-tab-btn"
+              role="tab"
+              aria-selected={mobileTab === 'modular'}
+              onClick={() => setUserSelectedTab('modular')}
+            >
+              Modular.com
+            </button>
+          </div>
+        ) : null}
+
+        <div className="mh-tab-panels">
+          {hasHandbookTab ? (
+            <div
+              className="mh-tab-panel"
+              role="tabpanel"
+              hidden={mobileTab !== 'handbook'}
+            >
+              <HandbookNavTree
+                sidebar={handbookSidebar!}
+                activePath={activePath ?? ''}
+                onNavigate={() => setMobileOpen(false)}
+              />
+            </div>
+          ) : null}
+
+          <div
+            className="mh-tab-panel"
+            role="tabpanel"
+            hidden={hasHandbookTab && mobileTab !== 'modular'}
           >
-            {marketingHeaderCtas.secondary.label}
-          </a>
-          <a className="mh-primary-cta" href={marketingHeaderCtas.primary.href}>
-            {marketingHeaderCtas.primary.label}
-          </a>
+            <ul className="mh-mobile-list" role="list">
+              {marketingHeaderItems.map((item) => (
+                <li key={item.type === 'link' ? item.label : item.menu.label}>
+                  {item.type === 'link' ? (
+                    <a className="mh-mobile-top-link" href={item.href}>
+                      {item.label}
+                    </a>
+                  ) : (
+                    <MobileMenuGroup menu={item.menu} />
+                  )}
+                </li>
+              ))}
+            </ul>
+            <div className="mh-mobile-actions">
+              <a
+                className="mh-secondary-cta"
+                href={marketingHeaderCtas.secondary.href}
+              >
+                {marketingHeaderCtas.secondary.label}
+              </a>
+              <a
+                className="mh-primary-cta"
+                href={marketingHeaderCtas.primary.href}
+              >
+                {marketingHeaderCtas.primary.label}
+              </a>
+            </div>
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/MarketingHeader/MarketingHeaderHost.tsx
+++ b/src/components/MarketingHeader/MarketingHeaderHost.tsx
@@ -1,13 +1,33 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { isValidElement, useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { useNavbarSecondaryMenu } from '@docusaurus/theme-common/internal';
+import type { PropSidebar } from '@docusaurus/plugin-content-docs';
 import MarketingHeader from './MarketingHeader';
 import headerStyles from './styles';
+
+// The docs sidebar tree isn't reachable via React Context from here (see
+// below), so we borrow it from the secondary-menu "teleport" that Docusaurus's
+// own default `@theme/DocSidebar/Mobile` already feeds on every doc page, and
+// read its raw props instead of rendering its (Infima-styled) element.
+type SecondaryMenuProps = { sidebar?: PropSidebar; path?: string };
+
+function useHandbookSidebarData(): { sidebar?: PropSidebar; activePath?: string } {
+  const { content } = useNavbarSecondaryMenu();
+  return useMemo(() => {
+    if (!isValidElement(content)) {
+      return {};
+    }
+    const props = content.props as SecondaryMenuProps;
+    return { sidebar: props.sidebar, activePath: props.path };
+  }, [content]);
+}
 
 export default function MarketingHeaderHost(): JSX.Element {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const rootRef = useRef<Root | null>(null);
   const styleRef = useRef<HTMLStyleElement | null>(null);
   const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
+  const { sidebar, activePath } = useHandbookSidebarData();
 
   useEffect(() => {
     const host = hostRef.current;
@@ -44,8 +64,14 @@ export default function MarketingHeaderHost(): JSX.Element {
 
   useEffect(() => {
     if (!rootRef.current || !shadowRoot) return;
-    rootRef.current.render(<MarketingHeader shadowRoot={shadowRoot} />);
-  }, [shadowRoot]);
+    rootRef.current.render(
+      <MarketingHeader
+        shadowRoot={shadowRoot}
+        handbookSidebar={sidebar}
+        activePath={activePath}
+      />
+    );
+  }, [shadowRoot, sidebar, activePath]);
 
   return (
     <div

--- a/src/components/MarketingHeader/styles.ts
+++ b/src/components/MarketingHeader/styles.ts
@@ -389,10 +389,13 @@ ul {
 }
 
 .mh-mobile-menu {
+  -webkit-overflow-scrolling: touch;
   background: #fff;
   border-top: 1px solid rgba(2, 12, 19, 0.08);
   box-shadow: 0 18px 50px rgba(2, 12, 19, 0.08);
   left: 0;
+  max-height: calc(100vh - 60px);
+  overflow-y: auto;
   padding: 20px 24px 28px;
   position: absolute;
   right: 0;

--- a/src/components/MarketingHeader/styles.ts
+++ b/src/components/MarketingHeader/styles.ts
@@ -388,19 +388,166 @@ ul {
   text-transform: lowercase;
 }
 
+.mh-mobile-backdrop {
+  background: rgba(2, 12, 19, 0.45);
+  bottom: 0;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 60px;
+  z-index: 180;
+}
+
+.mh-mobile-backdrop[hidden] {
+  display: none;
+}
+
 .mh-mobile-menu {
   -webkit-overflow-scrolling: touch;
   background: #fff;
   border-top: 1px solid rgba(2, 12, 19, 0.08);
-  box-shadow: 0 18px 50px rgba(2, 12, 19, 0.08);
+  box-shadow: 0 18px 50px rgba(2, 12, 19, 0.18);
+  display: flex;
+  flex-direction: column;
   left: 0;
   max-height: calc(100vh - 60px);
-  overflow-y: auto;
-  padding: 20px 24px 28px;
-  position: absolute;
+  position: fixed;
   right: 0;
   top: 60px;
   z-index: 190;
+}
+
+/* Segmented control (visually approximates Mantine's SegmentedControl; no
+   runtime dependency since it must render inside the header's Shadow DOM). */
+.mh-tab-track {
+  background: #f1f3f5;
+  border-radius: 0;
+  display: grid;
+  gap: 2px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 20px 24px 0;
+  padding: 3px;
+  position: relative;
+}
+
+.mh-tab-pill {
+  background: #637bff;
+  border-radius: 0;
+  height: calc(100% - 6px);
+  left: 3px;
+  position: absolute;
+  top: 3px;
+  transition: transform 200ms ease;
+  width: calc(50% - 3px);
+  z-index: 0;
+}
+
+.mh-tab-btn {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  color: #676d71;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 0;
+  position: relative;
+  transition: color 160ms ease;
+  z-index: 1;
+}
+
+.mh-tab-btn[aria-selected='true'] {
+  color: #fff;
+}
+
+.mh-tab-panels {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 24px 28px;
+}
+
+.mh-tab-panel[hidden] {
+  display: none;
+}
+
+/* Handbook tab: live sidebar tree */
+.mh-toc-welcome {
+  border-bottom: 1px solid rgba(2, 12, 19, 0.08);
+  border-radius: 0;
+  color: #020c13;
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  /* Bleed the highlight beyond the text's own alignment (like the article
+     items further down) so the current-page background reads as a proper
+     inset block instead of hugging the label text. */
+  margin: 0 -8px 6px;
+  padding: 8px 8px;
+}
+
+.mh-toc-welcome.current {
+  background: rgba(99, 123, 255, 0.12);
+  border-radius: 0;
+  color: #637bff;
+  font-weight: 600;
+}
+
+.mh-toc-category {
+  padding: 4px 0;
+}
+
+.mh-toc-category-header {
+  align-items: center;
+  background: none;
+  border: 0;
+  color: #676d71;
+  cursor: pointer;
+  display: flex;
+  font-size: 11.5px;
+  font-weight: 700;
+  justify-content: space-between;
+  letter-spacing: 0.04em;
+  padding: 10px 4px;
+  text-transform: uppercase;
+  width: 100%;
+}
+
+.mh-toc-category-header .mh-chevron {
+  transition: transform 160ms ease;
+}
+
+.mh-toc-category.expanded .mh-toc-category-header .mh-chevron {
+  transform: rotate(180deg);
+}
+
+.mh-toc-category-items {
+  display: none;
+}
+
+.mh-toc-category.expanded .mh-toc-category-items {
+  display: grid;
+  gap: 2px;
+}
+
+.mh-toc-article {
+  border-radius: 0;
+  color: #020c13;
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 8px 4px 8px 18px;
+}
+
+.mh-toc-article.current {
+  background: rgba(99, 123, 255, 0.12);
+  color: #637bff;
+  font-weight: 600;
+}
+
+.mh-toc-empty {
+  color: #676d71;
+  font-size: 13px;
+  padding: 16px 4px;
 }
 
 .mh-mobile-list {
@@ -522,8 +669,12 @@ ul {
     padding: 0 20px;
   }
 
-  .mh-mobile-menu {
-    padding: 18px 20px 24px;
+  .mh-tab-track {
+    margin: 18px 20px 0;
+  }
+
+  .mh-tab-panels {
+    padding: 14px 20px 24px;
   }
 
   .mh-mobile-actions {

--- a/src/components/MarketingHeader/styles.ts
+++ b/src/components/MarketingHeader/styles.ts
@@ -33,7 +33,6 @@ ul {
 
 .mh-header {
   background: #fff;
-  border-bottom: 1px solid var(--Elements-Twilight-30-70);
   color: #020c13;
   position: relative;
   z-index: 200;
@@ -44,7 +43,7 @@ ul {
   display: flex;
   justify-content: center;
   min-height: 60px;
-  padding: 0 24px;
+  padding: 0 var(--content-side-padding, 24px);
   position: relative;
   z-index: 99;
 }
@@ -53,7 +52,7 @@ ul {
   align-items: center;
   display: flex;
   justify-content: space-between;
-  max-width: 1200px;
+  max-width: var(--content-max-width, 1200px);
   min-height: 37px;
   position: relative;
   width: 100%;

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -357,6 +357,10 @@ $font-family-monospace:
   --ifm-navbar-height: 64px;
   --ifm-navbar-shadow: none;
   --ifm-alert-shadow: none;
+  // Shared with the navbar's shadow-DOM styles (MarketingHeader) so the
+  // sidebar + doc content align with the navbar's centered content column.
+  --content-max-width: 1200px;
+  --content-side-padding: 24px;
   --ifm-spacing-horizontal: 24px !important;
   --ifm-menu-link-padding-horizontal: 8px;
   letter-spacing: -0.32px;
@@ -596,10 +600,37 @@ table {
 // Sidebar
 // ============================================================
 
-// Sidebar panel: match page background, add right separator
+// Doc content row (sidebar + main): inset it to match the navbar's
+// centered content column instead of letting the sidebar run flush to
+// the viewport edge. Targets the flex row that directly parents the
+// sidebar, i.e. DocRoot's `docRoot` wrapper (theme-doc-sidebar-container's
+// parent), whose generated class name isn't otherwise addressable.
+@media (min-width: 997px) {
+  :has(> .theme-doc-sidebar-container) {
+    max-width: calc(
+      var(--content-max-width) + (var(--content-side-padding) * 2)
+    );
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: var(--content-side-padding);
+    padding-right: var(--content-side-padding);
+    // Nudge the whole row a bit further left than strict navbar-alignment math
+    // would place it.
+    position: relative;
+    left: -24px;
+  }
+}
+
+// Sidebar panel: match page background. Explicitly cancel the stock
+// theme's border-right (Docusaurus's own docSidebarContainer CSS module
+// also sets one), since it visibly runs the full sticky height of the
+// row — well past the actual menu content — as a stray vertical line.
 .theme-doc-sidebar-container {
   background-color: var(--ifm-background-color);
-  border-right: 1px solid var(--Elements-Twilight-20-70);
+  // !important: the stock docSidebarContainer CSS module sets its own
+  // border-right and is emitted after this rule in the bundled stylesheet,
+  // so equal specificity alone isn't enough to cancel it.
+  border-right: none !important;
 
   > div {
     max-height: 100vh;

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -852,6 +852,14 @@ nav.menu {
     color: var(--Elements-Twilight-60-50);
     font-size: 0.9rem;
   }
+
+  .table-of-contents__link {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
 }
 
 @mixin doc-actions-link-style {

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -31,8 +31,8 @@ export default function DocItemLayout({ children }: Props): ReactNode {
   const showRightRail = !docTOC.hidden;
 
   return (
-    <div className="row">
-      <div className={clsx('col', showRightRail && styles.docItemCol)}>
+    <div className={clsx('row', showRightRail && styles.docItemRow)}>
+      <div className={clsx('col', styles.docItemCol)}>
         <div className={styles.docItemContainer}>
           <article>
             <DocBreadcrumbs />
@@ -44,7 +44,7 @@ export default function DocItemLayout({ children }: Props): ReactNode {
         </div>
       </div>
       {showRightRail && (
-        <div className="col col--3 !mx-0">
+        <div className={clsx('col col--3 !mx-0', styles.rightRailCol)}>
           <div className={clsx(styles.rightRail, 'thin-scrollbar')}>
             {/* injection target for docusaurus-markdown-source-plugin */}
             <div className="doc-actions" />

--- a/src/theme/DocItem/Layout/styles.module.scss
+++ b/src/theme/DocItem/Layout/styles.module.scss
@@ -16,15 +16,59 @@
   overflow-y: auto;
   position: sticky;
   top: 96px;
-  padding-right: 20px;
+  margin-right: -20px;
   @media (max-width: 1280px) {
     top: 150px !important;
     max-height: calc(100vh - (var(--ifm-navbar-height) + 124px));
   }
 }
 
+// Infima's `.col` gives every column 24px of padding on *both* sides
+// (the grid gutter). On the left that correctly separates the TOC from the
+// reading column, but on the right it stacks with .rightRail's own 20px
+// padding (kept for scrollbar clearance), pushing the visible TOC content
+// 44px short of the column's actual (correctly aligned) right edge instead
+// of sitting flush against it.
+.rightRailCol {
+  padding-right: 0 !important;
+}
+
+// Infima's `.col` (flex: 1 0 0%, no max-width) and `.col--3` (flex: 0 0 25%)
+// already do exactly what we want here without any extra CSS: col--3 takes
+// a fixed 25% and .col's flex-grow absorbs *all* remaining space, so the
+// reading column stays responsive and the TOC col sits flush against the
+// row's right edge. Previous revisions capped .docItemCol's max-width and
+// tried to hand the leftover space to the TOC column via various
+// calc()/negative-margin hacks — that fought the flex layout instead of
+// using it, and drifted out of sync with the actual container width.
+.docItemCol {
+  // Flex items default to `min-width: auto`, which — combined with this
+  // column's `flex-basis: 0%` — means it refuses to shrink below its
+  // *content's* intrinsic min-content width (e.g. a wide table/calculator
+  // widget). Once that exceeds the column's fair-share width, the row
+  // (which is `flex-wrap: wrap`) can't fit the TOC column on the same
+  // line anymore and wraps it below all the reading content instead.
+  // min-width: 0 lets the column actually shrink to its allotted width and
+  // pushes any real overflow onto the content itself (which should scroll
+  // internally, e.g. `overflow-x: auto` on wide tables) instead of the
+  // whole two-column layout breaking.
+  min-width: 0;
+}
+
 @media (min-width: 997px) {
-  .docItemCol {
-    max-width: calc(75% - 60px) !important;
+  // The doc content `.container` (docMainContainer) has its own
+  // `--content-side-padding` (24px) on the right, matching the page-wide
+  // inset used to align the sidebar with the navbar's content column.
+  // That's correct for the reading column, but it leaves the TOC 24px
+  // short of the navbar's actual right edge (e.g. the "Sign up" button).
+  // Bleed the row through that padding so the TOC lines up exactly with
+  // it. `100%` resolves against .container's *content* box (inside its
+  // own left+right padding), so the extra width has to include that
+  // padding too, on top of the extra reach we want past it.
+  .docItemRow {
+    width: calc(
+      100% + (var(--ifm-spacing-horizontal) * 2) + var(--content-side-padding)
+    );
+    margin-right: calc(var(--content-side-padding) * -1);
   }
 }


### PR DESCRIPTION
This PR aligns the docs sidebar, reading column, and in-page TOC with the navbar's content edges so the layout reads as one consistent column system instead of drifting to the viewport edges. It also fixes the mobile navigation menu so handbook readers can actually get around the site on mobile.

- Aligns the sidebar and TOC with the navbar's content edges instead of running flush to the viewport
- Lets the reading column grow to fill the space between the sidebar and TOC, keeping the TOC flush against the page's right edge
- Fixes a flexbox bug where a wide table or calculator widget could wrap the TOC below the content entirely instead of sitting beside it
- Removes the sidebar's stray full-height border and the navbar's bottom hairline
- Removes the underline from "On this page" links in the mobile TOC menu
- Makes the mobile navigation menu scrollable so items aren't cut off on short viewports

## Mobile navigation ([DESN-1629](https://linear.app/modularml/issue/DESN-1629/llm-handbooks-mobile-menu-doesnt-show-sidebar-links))

Previously, the mobile menu only showed modular.com's marketing links (Product, Solutions, etc.) with no way to navigate the handbook's own chapters on mobile.

- Mobile menu now has two tabs — **Inference Handbook** and **Modular.com** — with Inference Handbook active by default
- The Handbook tab renders the real, live sidebar tree (not a hardcoded copy), always in sync with `sidebars.ts` and doc frontmatter, with the current article highlighted and each category's expand state mirroring its real `collapsed` setting
- Added a modal-style backdrop behind the open mobile menu so underlying page content isn't visible/undimmed beneath it
- The segmented control is a small hand-styled component (not a Mantine dependency), since the header renders inside a Shadow DOM that can't consume Mantine's global stylesheet