### PR TITLE
docs: Update github repo link

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -68,6 +68,6 @@ This handbook provides various interactive tools to help you learn by trying the
 
 ## Contributing
 
-We welcome contributions! If you spot an error, have suggestions for improvements, or want to add new topics, please open an issue or submit a pull request on our [GitHub repository](https://github.com/modularml/modular-fe/tree/main/llm-handbook).
+We welcome contributions! If you spot an error, have suggestions for improvements, or want to add new topics, please open an issue or submit a pull request on our [GitHub repository](https://github.com/modular/llm-inference-handbook).
 
 <ContactSection />


### PR DESCRIPTION
I believe the right repo link should be `https://github.com/modular/llm-inference-handbook` after the migration.