### PR TITLE
docs: Remove overflowing to cloud content

### DIFF
--- a/docs/getting-started/bring-your-own-cloud.md
+++ b/docs/getting-started/bring-your-own-cloud.md
@@ -97,9 +97,9 @@ For example, Modular Cloud BYOC provisions compute directly in your account, so 
 
 BYOC keeps your infrastructure cloud-neutral. You’re not tied to the stack or hardware of a single cloud provider. That means your LLM deployment strategy remains future-proof. As your needs change, you can freely move workloads across clouds, GPUs, or orchestration tools.
 
-## SaaS vs. BYOC vs. On-prem vs. Hybrid
+## SaaS vs. BYOC vs. On-prem
 
-Choosing how to deploy your LLMs is essentially about where your models live and who runs the infrastructure. Each deployment model — SaaS, BYOC, On-prem, or Hybrid (On-prem + BYOC) — offers different trade-offs between control, cost, and complexity.
+Choosing how to deploy your LLMs is essentially about where your models live and who runs the infrastructure. Each deployment model — SaaS, BYOC, or On-prem — offers different trade-offs between control, cost, and complexity.
 
 Here’s a quick comparison:
 
@@ -108,9 +108,8 @@ Here’s a quick comparison:
 | SaaS | Vendor’s cloud | Vendor | Low: data resides in vendor’s multi-tenant environment | Fast setup, minimal ops overhead, quick prototyping, non-sensitive data |
 | BYOC | Customer’s cloud account (e.g., AWS, GCP, Azure) | Shared between vendor and customer | High: data stays in customer’s VPC | Enterprises with security/compliance needs, GPU cost optimization, flexible scaling |
 | [On-prem](../getting-started/on-prem-llms) | Customer’s private data center | Customer |  Full: data and compute remain entirely on customer infrastructure | Air-gapped or highly regulated industries (e.g., defense, healthcare) |
-| [Hybrid (On-prem + BYOC)](../getting-started/on-prem-llms#overflowing-to-the-cloud-a-hybrid-approach) | Split between customer data center and cloud account | Shared between customer and vendor | Full: on-prem for sensitive workloads, cloud for burst capacity | Organizations needing more flexibility while maintaining strict data boundaries |
 
-For most enterprise LLM workloads, BYOC provides the best middle ground. It’s fast to deploy, secure by design, and cost-efficient at scale. However, hybrid architectures are becoming the bridge between full control and global agility. In a hybrid setup, you can deploy models on-prem for maximum control, data security, and compliance, while overflowing to cloud GPUs during traffic spikes.
+For most enterprise LLM workloads, BYOC provides the best middle ground. It’s fast to deploy, secure by design, and cost-efficient at scale.
 
 ---
 
@@ -131,9 +130,9 @@ With our BYOC deployment, you can:
 
 ## Frequently asked questions
 
-### Can BYOC work with multi-cloud or hybrid deployments?
+### Can BYOC work with multi-cloud deployments?
 
-Yes. BYOC fits naturally into hybrid and multi-cloud architectures. Depending on your securiy and compliance policy, sensitive workloads can stay on-prem or in one cloud, while overflow or global inference traffic scales into others.
+Yes. BYOC fits naturally into multi-cloud architectures. Depending on your security and compliance policy, sensitive workloads can stay in one cloud, while global inference traffic scales into others.
 
 ### How does BYOC differ from SaaS?
 

--- a/docs/getting-started/on-prem-llms.md
+++ b/docs/getting-started/on-prem-llms.md
@@ -58,30 +58,3 @@ No universal answer exists to whether on-prem is “better” than cloud. Each o
 | **Flexibility** | Best for long-term, stable workloads | Best for rapid experimentation and dynamic workloads |
 
 The decision usually depends on compliance requirements, traffic patterns, and how much operational complexity your team is willing to manage.
-
-## Overflowing to the cloud: A hybrid approach
-
-On-prem deployments give you control, but they can’t always handle bursty or unpredictable traffic. GPU procurement cycles are long, and over-provisioning to cover peak hours leads to wasted resources. That’s where a hybrid approach comes in.
-
-In a hybrid setup, your on-prem cluster serves as the baseline for secure, predictable workloads. When demand exceeds local capacity, traffic can overflow to the cloud, where GPUs can be provisioned on demand. This lets you balance:
-
-- **Control**: Keep sensitive or regulated workloads running in your own data center.
-- **Availability**: Use cloud GPUs to handle spikes in usage without overbuilding on-prem hardware.
-- **Cost**: Rely on lower-cost reserved GPUs for steady demand in your on-prem environment, and only pay for overflowed cloud GPUs during peaks.
-
-Hybrid deployments give you flexibility without forcing you to compromise entirely on control, availability, or price. Many enterprises benefit from this pattern: security and compliance on-prem, elasticity in the cloud.
-
----
-
-We work to provide a unified compute fabric — a layer of orchestration and abstraction that allows enterprises to deploy and scale inference workloads across:
-
-- On-prem GPU clusters
-- Bring Your Own Cloud (including NeoCloud, multi-cloud and multi-region setups) environments
-
-If your on-prem cluster runs out of capacity, we allow you to seamlessly overflow traffic to cloud GPUs. This ensures you always have enough compute power as you scale.
-
-<Diagram name="overflow-to-cloud-gpus" alt="On-prem base capacity with dynamic overflow to cloud GPUs over time" />
-
-<div style={{ margin: '3rem 0' }}>
-<a className="btn-outline" href="https://www.modular.com/request-demo?utm_source=llm_handbook">Talk to us</a>
-</div>

--- a/docs/llm-inference-basics/llm-inference-metrics.md
+++ b/docs/llm-inference-basics/llm-inference-metrics.md
@@ -141,12 +141,6 @@ There are two common ways to measure throughput:
     - Larger batches and higher concurrency can improve aggregate TPS by keeping the GPU busy, but may increase queueing time, TTFT, or per-user TPOT.
     
     As the number of concurrent requests increases, the total TPS also grows, until the LLM hits the saturation point of available compute resources. Beyond this point, performance might decrease because the LLM is over capacity.
-
----
-
-<div style={{ margin: '3rem 0' }}>
-<a className="btn-outline" href="https://www.modular.com/request-demo?utm_source=llm_handbook">Talk to us</a>
-</div>
     
 ## Goodput
 


### PR DESCRIPTION
The hybrid deployment feature (on prem first, overflowing to cloud GPUs when needed) is specific to BentoCloud, not applicable to Modular Cloud yet. We can add that later when it is supported.