### PR TITLE
feat: add "edit this page" actions to right rail and update "copy" icon

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -82,6 +82,11 @@ const config: Config = {
       'docusaurus-markdown-source-plugin',
       {
         docsPath: '/',
+        fullyQualifiedLinks: true,
+        directive:
+          '> Markdown versions of all pages are available by appending .md to any URL.',
+        htmlDirective:
+          'IMPORTANT: To view this page as Markdown, append `.md` to the URL.',
         containerSelector: '.doc-actions',
         copyButtonText: 'Copy as Markdown',
         copiedButtonText: 'Copied!',
@@ -93,6 +98,7 @@ const config: Config = {
         routeBasePath: '/',
         path: './docs',
         sidebarPath: './sidebars.ts',
+        editUrl: 'https://github.com/modular/llm-inference-handbook/edit/main/',
         breadcrumbs: true,
         exclude: ['**/README.md', '**/LICENSE', 'adr/**'],
         remarkPlugins: [remarkMath],

--- a/src/components/DocActions.tsx
+++ b/src/components/DocActions.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import { PencilIcon } from '@site/src/shared/Svgs/PencilIcon';
+
+export default function DocActions({ editUrl }: { editUrl?: string }) {
+  if (!editUrl) {
+    return null;
+  }
+
+  return (
+    <Link to={editUrl} className="theme-edit-this-page">
+      <PencilIcon size={14} />
+      Edit this page
+    </Link>
+  );
+}

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -902,23 +902,44 @@ nav.menu {
   a.view-source-link {
     @include doc-actions-link-style;
   }
+}
+
+/* "Copy page" button - styled to match "Edit this page" link */
+.markdown-actions-container {
+  display: inline-flex;
+  align-items: center;
 
   .markdown-copy-button {
     @include doc-actions-link-style;
-    background: none;
+    background-color: transparent;
     border: none;
-    padding: 0;
-    margin: 0;
-    font: inherit;
-    text-align: left;
     letter-spacing: inherit;
-    white-space: unset;
+    padding: 0;
+    font-size: 0.875rem;
+    font-weight: 400;
     cursor: pointer;
 
-    svg path {
-      fill: currentColor;
+    svg {
+      margin: 0;
+
+      path {
+        fill: currentColor;
+      }
     }
   }
+}
+
+/* Visually hidden but present in server-rendered HTML for AI agents (AFD llms-txt-directive-html) */
+.llms-directive {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 // Mantine Alert overrides (admonitions) — Light mode only

--- a/src/shared/Svgs/PencilIcon.tsx
+++ b/src/shared/Svgs/PencilIcon.tsx
@@ -1,0 +1,27 @@
+import { rem } from '@mantine/core';
+import type { JSX } from 'react';
+
+interface PencilIconProps extends React.ComponentPropsWithoutRef<'svg'> {
+  size?: number | string;
+}
+
+export function PencilIcon({
+  size = 22,
+  style,
+  fill,
+  ...others
+}: PencilIconProps): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ width: rem(size), height: rem(size), ...style }}
+      {...others}
+    >
+      <g stroke="currentColor" strokeWidth="1.2">
+        <path d="m5.33 14.67 9.34-9.34-4-4-9.34 9.34v4h4ZM8.33 3.67l4 4" />
+      </g>
+    </svg>
+  );
+}

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -8,6 +8,7 @@ import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
 import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
 import DocItemContent from '@theme/DocItem/Content';
 import DocBreadcrumbs from '@theme/DocBreadcrumbs';
+import DocActions from '@site/src/components/DocActions';
 import type { Props } from '@theme/DocItem/Layout';
 import styles from './styles.module.scss';
 
@@ -27,8 +28,11 @@ function useDocTOC() {
 }
 
 export default function DocItemLayout({ children }: Props): ReactNode {
+  const {
+    metadata: { editUrl },
+  } = useDoc();
   const docTOC = useDocTOC();
-  const showRightRail = !docTOC.hidden;
+  const showRightRail = Boolean(editUrl) || !docTOC.hidden;
 
   return (
     <div className={clsx('row', showRightRail && styles.docItemRow)}>
@@ -46,8 +50,9 @@ export default function DocItemLayout({ children }: Props): ReactNode {
       {showRightRail && (
         <div className={clsx('col col--3 !mx-0', styles.rightRailCol)}>
           <div className={clsx(styles.rightRail, 'thin-scrollbar')}>
-            {/* injection target for docusaurus-markdown-source-plugin */}
-            <div className="doc-actions" />
+            <div className="doc-actions">
+              <DocActions editUrl={editUrl} />
+            </div>
             {docTOC.desktop}
           </div>
         </div>

--- a/src/theme/MarkdownCopyIcon/index.js
+++ b/src/theme/MarkdownCopyIcon/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import IconCopy from '@theme/Icon/Copy';
+
+/* Override the default copy icon in markdown_docusaurus_plugin */
+export default function MarkdownCopyIconOverride({ size, style }) {
+  return <IconCopy style={{ width: 14, height: 14, ...style }} />;
+}


### PR DESCRIPTION
- Add "Edit this page" link with pencil icon in the doc-actions rail
- Style "Copy as Markdown" as a text link matching the edit action
- Override MarkdownCopyIcon to use the 14px Docusaurus copy icon
- Add markdown-source plugin agent directives to find `.md` files (hide from viewers with CSS)
- Enable `fullyQualifiedLinks` so the .md files use full domain links instead of relative links to our own pages
- Show the right rail when an edit link exists, even without a TOC