### PR TITLE
enable trailing slash for links (fix false-positive 404s from crawlers)

### DIFF
--- a/docs/getting-started/bring-your-own-cloud.md
+++ b/docs/getting-started/bring-your-own-cloud.md
@@ -107,7 +107,7 @@ Here’s a quick comparison:
 | --- | --- | --- | --- | --- |
 | SaaS | Vendor’s cloud | Vendor | Low: data resides in vendor’s multi-tenant environment | Fast setup, minimal ops overhead, quick prototyping, non-sensitive data |
 | BYOC | Customer’s cloud account (e.g., AWS, GCP, Azure) | Shared between vendor and customer | High: data stays in customer’s VPC | Enterprises with security/compliance needs, GPU cost optimization, flexible scaling |
-| [On-prem](../getting-started/on-prem-llms) | Customer’s private data center | Customer |  Full: data and compute remain entirely on customer infrastructure | Air-gapped or highly regulated industries (e.g., defense, healthcare) |
+| [On-prem](/getting-started/on-prem-llms/) | Customer’s private data center | Customer |  Full: data and compute remain entirely on customer infrastructure | Air-gapped or highly regulated industries (e.g., defense, healthcare) |
 
 For most enterprise LLM workloads, BYOC provides the best middle ground. It’s fast to deploy, secure by design, and cost-efficient at scale.
 
@@ -120,7 +120,7 @@ With our BYOC deployment, you can:
 - Run models inside your own VPC across providers like AWS, GCP, or Azure and leverage your existing credits and commits
 - Keep your data and workloads fully within your environment
 - Run and scale inference across NVIDIA, AMD, CPUs, and more in the same BYOC deployment
-- Apply the latest distributed inference techniques like [prefill-decode disaggregation](../inference-optimization/prefill-decode-disaggregation) in your private cloud
+- Apply the latest distributed inference techniques like [prefill-decode disaggregation](/inference-optimization/prefill-decode-disaggregation/) in your private cloud
 
 <div style={{ margin: '3rem 0' }}>
 <a className="btn-outline" href="https://www.modular.com/request-demo?utm_source=llm_handbook">Schedule a Demo</a>

--- a/docs/getting-started/calculating-gpu-memory-for-llms.md
+++ b/docs/getting-started/calculating-gpu-memory-for-llms.md
@@ -17,11 +17,11 @@ If you're planning to self-host an LLM, one of the first things you'll need to e
 During LLM inference, the model weights must live in GPU memory while the model is serving requests. This fixed baseline depends mainly on the model’s size and the precision used for the weights.
 
 - **Model size (number of parameters)**. Larger models need more memory. Models with tens or hundreds of billions of parameters usually require high-end GPUs like NVIDIA H100 or H200.
-- **Bit precision**. The precision used (e.g., FP16, FP8, INT8) affects memory consumption. Lower precision formats can significantly reduce the memory footprint, but may affect accuracy. For models on Hugging Face, you can often find the weight data type in the `config.json` file. The `torch_dtype` attribute indicates the precision used for the model weights. See [LLM quantization](../model-preparation/llm-quantization) for details.
+- **Bit precision**. The precision used (e.g., FP16, FP8, INT8) affects memory consumption. Lower precision formats can significantly reduce the memory footprint, but may affect accuracy. For models on Hugging Face, you can often find the weight data type in the `config.json` file. The `torch_dtype` attribute indicates the precision used for the model weights. See [LLM quantization](/model-preparation/llm-quantization/) for details.
 
 Weight memory is not the full serving requirement. For example, a 7B model in FP16 needs roughly 14 GB just for weights, so it may load on a 16 GB GPU. However, that does not mean the GPU has enough headroom for production inference. A single short request may work, but longer prompts, larger batches, or more concurrent users can quickly exhaust the remaining memory.
 
-The [KV cache](../inference-optimization/kv-cache-offloading) is usually the largest runtime overhead. It stores attention keys and values so the model can reuse previous tokens during decoding instead of recomputing them. The cache grows with sequence length and the number of active requests. Serving engines also need memory for temporary activations, workspace buffers, framework allocations, and sometimes CUDA graphs. If you leave only a tiny amount of GPU memory beyond the weights, you will be limited to short contexts, small batches, and low concurrency.
+The [KV cache](/inference-optimization/kv-cache-offloading/) is usually the largest runtime overhead. It stores attention keys and values so the model can reuse previous tokens during decoding instead of recomputing them. The cache grows with sequence length and the number of active requests. Serving engines also need memory for temporary activations, workspace buffers, framework allocations, and sometimes CUDA graphs. If you leave only a tiny amount of GPU memory beyond the weights, you will be limited to short contexts, small batches, and low concurrency.
 
 A rough formula for estimating serving memory is:
 
@@ -45,5 +45,5 @@ Not all GPUs support all precision formats natively. A100 and other Ampere GPUs 
 
 <LinkList>
   ## Additional resources
-  * [GPU architecture fundamentals](../kernel-optimization/gpu-architecture-fundamentals)
+  * [GPU architecture fundamentals](/kernel-optimization/gpu-architecture-fundamentals/)
 </LinkList>

--- a/docs/getting-started/choosing-the-right-gpu.md
+++ b/docs/getting-started/choosing-the-right-gpu.md
@@ -61,7 +61,7 @@ Workstation cards sit between consumer and data center hardware. They’re a goo
 
 Enterprises rely on data center GPUs for large-scale AI inference and high-performance computing (HPC) workloads. They offer high VRAM (40–192GB), strong memory bandwidth, and features like multi-instance GPU (MIG) or NVLink for scaling across clusters. Examples include NVIDIA A100, H100, and B200, as well as AMD MI300X and MI350X.
 
-For teams renting cloud compute or [deploying LLM on-prem](./on-prem-llms), data center GPUs are usually the most practical choice.
+For teams renting cloud compute or [deploying LLM on-prem](/getting-started/on-prem-llms/), data center GPUs are usually the most practical choice.
 
 ## Key considerations for choosing GPUs
 
@@ -69,13 +69,13 @@ When selecting GPUs, remember that raw benchmark numbers don’t tell the whole 
 
 ### GPU memory (VRAM)
 
-[VRAM](../kernel-optimization/gpu-architecture-fundamentals) sets the ceiling on model size and context length because everything the GPU touches during inference must live in the memory: the model weights, the activations, and the KV cache. Weights determine the baseline footprint, so the model has to fit before you can serve it at all. For example, DeepSeek V3 and R1, with 671B parameters, require 8 NVIDIA H200 GPUs (141 GB each) to run. In contrast, smaller models such as Phi-3 can fit within 16–24GB when quantized. The KV cache then consumes whatever VRAM is left, which limits how long a context you can support.
+[VRAM](/kernel-optimization/gpu-architecture-fundamentals/) sets the ceiling on model size and context length because everything the GPU touches during inference must live in the memory: the model weights, the activations, and the KV cache. Weights determine the baseline footprint, so the model has to fit before you can serve it at all. For example, DeepSeek V3 and R1, with 671B parameters, require 8 NVIDIA H200 GPUs (141 GB each) to run. In contrast, smaller models such as Phi-3 can fit within 16–24GB when quantized. The KV cache then consumes whatever VRAM is left, which limits how long a context you can support.
 
-In production, the major challenge is often the KV cache. Its size grows linearly with sequence length, meaning long-context workloads can quickly exhaust memory. To avoid bottlenecks, you need [distributed inference](../infrastructure-and-operations/distributed-inference) techniques like [prefill-decode disaggregation](../inference-optimization/prefill-decode-disaggregation) and [KV cache offloading](../inference-optimization/kv-cache-offloading).
+In production, the major challenge is often the KV cache. Its size grows linearly with sequence length, meaning long-context workloads can quickly exhaust memory. To avoid bottlenecks, you need [distributed inference](/infrastructure-and-operations/distributed-inference/) techniques like [prefill-decode disaggregation](/inference-optimization/prefill-decode-disaggregation/) and [KV cache offloading](/inference-optimization/kv-cache-offloading/).
 
 ### Memory bandwidth
 
-Memory bandwidth is how fast the GPU can move data between its [HBM](../kernel-optimization/gpu-architecture-fundamentals/#hbm-high-bandwidth-memory) and the compute cores, measured in GB/s or TB/s. For LLM inference, it is one of the most important specifications, because the **decode phase is memory-bound**. To generate each new token, the GPU must repeatedly stream most or all model weights (plus the growing KV cache) from HBM, while doing relatively little computation per byte of data read.
+Memory bandwidth is how fast the GPU can move data between its [HBM](/kernel-optimization/gpu-architecture-fundamentals/#hbm-high-bandwidth-memory) and the compute cores, measured in GB/s or TB/s. For LLM inference, it is one of the most important specifications, because the **decode phase is memory-bound**. To generate each new token, the GPU must repeatedly stream most or all model weights (plus the growing KV cache) from HBM, while doing relatively little computation per byte of data read.
 
 As a result, the theoretical upper bound for single-stream decode speed is approximately:
 
@@ -85,7 +85,7 @@ maximum decode tokens/sec ≈ memory bandwidth / bytes read per token
 
 For example, a 70B-parameter model in FP16 contains about 140 GB of weights. On an H100 SXM with roughly 3.35 TB/s of HBM bandwidth, this means a theoretical ceiling of about 24 tokens/s per sequence before accounting for any other overhead (e.g., KV cache).
 
-This is why the prefill phase (which processes the prompt in parallel) behaves very differently from decode. It also explains why [batching](../inference-optimization/static-dynamic-continuous-batching) improves throughput so effectively: the same weight reads can be reused across many sequences, allowing the GPU to trade memory-bandwidth pressure for additional compute work.
+This is why the prefill phase (which processes the prompt in parallel) behaves very differently from decode. It also explains why [batching](/inference-optimization/static-dynamic-continuous-batching/) improves throughput so effectively: the same weight reads can be reused across many sequences, allowing the GPU to trade memory-bandwidth pressure for additional compute work.
 
 ### Compute throughput
 
@@ -94,14 +94,14 @@ Compute throughput is how many math operations the GPU can perform per second, m
 When reading specification sheets, keep a few caveats in mind:
 
 - **Watch the asterisks**. Vendors often quote peak FLOPS with sparsity or at the lowest supported precision. Compare cards at the same precision and the same dense/sparse assumption.
-- **FLOPS isn't the user-facing metric**. What you ultimately care about is [tokens per second and latency](../llm-inference-basics/llm-inference-metrics) (TTFT and ITL). A GPU can have huge FLOPS yet be bottlenecked by [memory bandwidth](#memory-bandwidth) during decode, so the two numbers need to be read together.
+- **FLOPS isn't the user-facing metric**. What you ultimately care about is [tokens per second and latency](/llm-inference-basics/llm-inference-metrics/) (TTFT and ITL). A GPU can have huge FLOPS yet be bottlenecked by [memory bandwidth](#memory-bandwidth) during decode, so the two numbers need to be read together.
 - **Precision support is a hard gate**. Native FP8 needs NVIDIA H-series or newer. Older cards fall back to higher precision, losing the throughput advantage.
 
-To push effective throughput further, apply techniques like [speculative decoding](../inference-optimization/speculative-decoding), [prefill-decode disaggregation](../inference-optimization/prefill-decode-disaggregation), and [continuous batching](../inference-optimization/static-dynamic-continuous-batching).
+To push effective throughput further, apply techniques like [speculative decoding](/inference-optimization/speculative-decoding/), [prefill-decode disaggregation](/inference-optimization/prefill-decode-disaggregation/), and [continuous batching](/inference-optimization/static-dynamic-continuous-batching/).
 
 ### GPU interconnect
 
-GPU interconnect determines how quickly you can exchange data (e.g., KV cache) when your workload spans more than one GPU, both within a single node and across multiple nodes. This is especially important for large models that use [tensor parallelism, pipeline parallelism](../inference-optimization/data-tensor-pipeline-expert-hybrid-parallelism), or other [distributed inference techniques](../infrastructure-and-operations/distributed-inference). If the interconnect is slow, adding more GPUs may increase memory capacity but fail to deliver the expected throughput or latency improvements.
+GPU interconnect determines how quickly you can exchange data (e.g., KV cache) when your workload spans more than one GPU, both within a single node and across multiple nodes. This is especially important for large models that use [tensor parallelism, pipeline parallelism](/inference-optimization/data-tensor-pipeline-expert-hybrid-parallelism/), or other [distributed inference techniques](/infrastructure-and-operations/distributed-inference/). If the interconnect is slow, adding more GPUs may increase memory capacity but fail to deliver the expected throughput or latency improvements.
 
 - **Intra-node interconnect**. This refers to communication between GPUs inside the same server. High-bandwidth fabrics such as NVIDIA NVLink/NVSwitch or AMD Infinity Fabric are often much faster than PCIe-only setups for tightly coupled multi-GPU inference. On an H100, for example, NVLink delivers 900 GB/s of bidirectional GPU-to-GPU bandwidth, [about 7 times faster](https://www.nvidia.com/en-us/data-center/h100/) than the bidirectional bandwidth of a single PCIe 5.0 link at 128 GB/s.
 - **Inter-node interconnect**. This refers to networking between different GPU servers. A single node typically contains 4 to 8 GPUs, although larger or specialized systems exist. Once a model or workload exceeds what a single node can support due to limits like power, cooling, or form factor, communication must go over the network. A practical solution is InfiniBand (with GPUDirect RDMA) or highly tuned RoCEv2 Ethernet.
@@ -126,7 +126,7 @@ A GPU is only as effective as the software that supports it. NVIDIA benefits fro
 
 ## Matching GPUs to open-source LLMs
 
-Different models perform best on different types of GPUs. The table below maps popular NVIDIA and AMD GPUs to suitable open-source LLMs. Some models require **multiple GPUs to meet VRAM demands** or you may need optimization techniques like [quantization](../model-preparation/llm-quantization).
+Different models perform best on different types of GPUs. The table below maps popular NVIDIA and AMD GPUs to suitable open-source LLMs. Some models require **multiple GPUs to meet VRAM demands** or you may need optimization techniques like [quantization](/model-preparation/llm-quantization/).
 
 <GPUTable />
 
@@ -138,7 +138,7 @@ Things to keep in mind:
 
 - **FP8 support**. If you choose NVIDIA GPUs, note that LLMs that rely on native FP8 weights can only run on NVIDIA H-series (or newer) GPUs. This is because A-series cards lack FP8 hardware support.
 - **Single vs. Multi-GPU**. Some models can run on one card, but usually performance improves with multiple GPUs (e.g., for high-concurrency scenarios).
-- **Hardware flexibility**. Most models can run on different hardware. For instance, gpt-oss-20b and gpt-oss-120b can run on NVIDIA A100, H100, H200, B200 GPUs, or AMD MI300X, MI325X, MI355X GPUs. The limiting factor is usually VRAM and cluster size, not architecture. Learn how to [calculate GPU memory for serving LLMs](./calculating-gpu-memory-for-llms).
+- **Hardware flexibility**. Most models can run on different hardware. For instance, gpt-oss-20b and gpt-oss-120b can run on NVIDIA A100, H100, H200, B200 GPUs, or AMD MI300X, MI325X, MI355X GPUs. The limiting factor is usually VRAM and cluster size, not architecture. Learn how to [calculate GPU memory for serving LLMs](/getting-started/calculating-gpu-memory-for-llms/).
 
 ---
 
@@ -163,16 +163,16 @@ Weight loading happens at service startup. Here is the specific pipeline:
     - Weights are temporarily placed in system memory
     - Often deserialized or memory-mapped
     - CPU RAM bandwidth: ~50–200 GB/s for typical configurations
-3. Transferred to [GPU HBM](../kernel-optimization/gpu-architecture-fundamentals/#hbm-high-bandwidth-memory)
+3. Transferred to [GPU HBM](/kernel-optimization/gpu-architecture-fundamentals/#hbm-high-bandwidth-memory)
 4. Cached there for the lifetime of the serving process
 
 Once copied, weights are stored in HBM and are ready for repeated reads during every forward pass. For decoding, weights are NOT reloaded from disk or CPU; they are reused directly from HBM.
 
-If you are using [tensor parallelism](../inference-optimization/data-tensor-pipeline-expert-hybrid-parallelism), each GPU holds a slice of every layer's weight matrices.
+If you are using [tensor parallelism](/inference-optimization/data-tensor-pipeline-expert-hybrid-parallelism/), each GPU holds a slice of every layer's weight matrices.
 
 ### What is the best GPU comparison tool for AI workloads?
 
-Most generic GPU comparison tools focus on gaming or graphics performance, which doesn’t reflect real AI inference workloads. For LLMs, you need tools that measure [throughput and latency metrics like TTFT and ITL](../llm-inference-basics/llm-inference-metrics).
+Most generic GPU comparison tools focus on gaming or graphics performance, which doesn’t reflect real AI inference workloads. For LLMs, you need tools that measure [throughput and latency metrics like TTFT and ITL](/llm-inference-basics/llm-inference-metrics/).
 
 You can start by checking open-source leaderboards from frameworks such as vLLM, SGLang, and TensorRT-LLM. They provide ready-to-use scripts that help you compare inference performance across different GPUs.
 
@@ -198,7 +198,7 @@ On most systems, you can quickly verify your GPU type using command-line tools:
 
 ### How important are CUDA and driver versions when choosing a GPU?
 
-Very important. GPU performance isn’t just about the hardware. Your NVIDIA driver, CUDA version, and framework build (e.g., PyTorch, vLLM, SGLang, TensorRT-LLM) all need to line up. When they don’t, you’ll see errors, slowdowns, or missing features like FP8 or [FlashAttention](../kernel-optimization/flashattention). If you want the lower-level reason these mismatches matter, refer to [GPU architecture fundamentals](../kernel-optimization/gpu-architecture-fundamentals).
+Very important. GPU performance isn’t just about the hardware. Your NVIDIA driver, CUDA version, and framework build (e.g., PyTorch, vLLM, SGLang, TensorRT-LLM) all need to line up. When they don’t, you’ll see errors, slowdowns, or missing features like FP8 or [FlashAttention](/kernel-optimization/flashattention/). If you want the lower-level reason these mismatches matter, refer to [GPU architecture fundamentals](/kernel-optimization/gpu-architecture-fundamentals/).
 
 For NVIDIA GPUs:
 

--- a/docs/getting-started/choosing-the-right-inference-framework.md
+++ b/docs/getting-started/choosing-the-right-inference-framework.md
@@ -15,7 +15,7 @@ Once you’ve selected a model, the next step is choosing how to run it. Your ch
 
 ## What are inference frameworks?
 
-An inference framework is the software layer that loads a model, runs it on the right hardware, and serves outputs to applications. For LLMs, this usually means more than calling the `forward()` function of the model. A framework also manages token generation, [KV cache](../inference-optimization/kv-cache-offloading), batching, streaming responses, memory limits, and request handling.
+An inference framework is the software layer that loads a model, runs it on the right hardware, and serves outputs to applications. For LLMs, this usually means more than calling the `forward()` function of the model. A framework also manages token generation, [KV cache](/inference-optimization/kv-cache-offloading/), batching, streaming responses, memory limits, and request handling.
 
 You may also see these tools called inference runtimes, inference engines, inference backends, or model servers. The exact meaning varies by project, but the core job is the same: make model execution efficient and usable outside a training notebook.
 
@@ -31,7 +31,7 @@ Inference frameworks handle the serving-specific work that raw model execution d
 - **KV cache management**: Store attention state efficiently for long prompts and multi-turn chats.
 - **Streaming**: Return tokens as they are generated instead of waiting for the full response.
 - **Memory control**: Fit larger models and more concurrent requests into limited GPU memory.
-- **Production APIs**: Expose [OpenAI-compatible](../model-interaction/openai-compatible-api) or framework-specific endpoints.
+- **Production APIs**: Expose [OpenAI-compatible](/model-interaction/openai-compatible-api/) or framework-specific endpoints.
 - **Multi-GPU support**: Split large models across devices when one GPU is not enough.
 
 These frameworks hide much of the model execution complexity behind serving options you can tune. Here is an example of using vLLM to serve DeepSeek-V4-Flash. You can tune different configurations directly without touching the model itself. vLLM automatically handles it for you.
@@ -61,7 +61,7 @@ Popular inference frameworks for building high-throughput, low-latency LLM appli
 
 - [vLLM](https://github.com/vllm-project/vllm). A high-performance inference engine optimized for serving LLMs. It is known for its efficient use of GPU resources and fast decoding capabilities.
 - [SGLang](https://github.com/sgl-project/sglang). A fast serving framework for LLMs and vision language models. It makes your interaction with models faster and more controllable by co-designing the backend runtime and frontend language.
-- [Max](https://github.com/modular/modular). A high-performance AI serving framework from Modular. It provides an integrated suite of tools for AI compute workloads across CPUs and GPUs and supports customization at both the model and [kernel level](../kernel-optimization/kernel-optimization-tools).
+- [Max](https://github.com/modular/modular). A high-performance AI serving framework from Modular. It provides an integrated suite of tools for AI compute workloads across CPUs and GPUs and supports customization at both the model and [kernel level](/kernel-optimization/kernel-optimization-tools/).
 - [LMDeploy](https://github.com/InternLM/lmdeploy). An inference backend focusing on delivering high decoding speed and efficient handling of concurrent requests. It supports various quantization techniques, making it suitable for deploying large models with reduced memory requirements.
 - [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM). An inference backend that leverages NVIDIA's TensorRT, a high-performance deep learning inference library. It is optimized for running large models on NVIDIA GPUs, providing fast inference and support for advanced optimizations like quantization.
 - [Hugging Face TGI](https://github.com/huggingface/text-generation-inference). A toolkit for deploying and serving LLMs. It is used in production at Hugging Face to power Hugging Chat, the Inference API and Inference Endpoint. Note that Hugging Face TGI is now in **maintenance mode**. This means it is still supported and usable, but there will no longer be major feature development or new performance optimizations. If you’re running TGI in production, it’s worth planning an upgrade path as your performance or scaling needs grow.
@@ -136,7 +136,7 @@ python -m sglang.launch_server \
   --port 30000
 ```
 
-Because both servers expose an [OpenAI-compatible API](../model-interaction/openai-compatible-api), the application code can use the same client interface like this:
+Because both servers expose an [OpenAI-compatible API](/model-interaction/openai-compatible-api/), the application code can use the same client interface like this:
 
 ```python
 from openai import OpenAI
@@ -187,7 +187,7 @@ They often begin with tools like Ollama to run models locally on a laptop or sma
 
 From there, teams move to high-performance server runtimes like vLLM. These frameworks provide continuous batching, KV cache optimizations, and improved GPU utilization on data center GPUs. However, most of these runtimes lack built-in multi-region routing, automatic failover, and true horizontal scaling. GPU provisioning, performance tuning, and fault tolerance also remain complex and time-consuming to implement.
 
-When teams need to run and scale inference across multiple GPU clusters, regions, or clouds, they typically adopt [distributed inference](../infrastructure-and-operations/distributed-inference) platforms to handle autoscaling, routing, observability, and compliance requirements at production scale. These platforms provide advanced features out of the box, which means your engineering team can focus on product innovation instead of building and maintaining infrastructure.
+When teams need to run and scale inference across multiple GPU clusters, regions, or clouds, they typically adopt [distributed inference](/infrastructure-and-operations/distributed-inference/) platforms to handle autoscaling, routing, observability, and compliance requirements at production scale. These platforms provide advanced features out of the box, which means your engineering team can focus on product innovation instead of building and maintaining infrastructure.
 
 ## FAQs
 
@@ -201,9 +201,9 @@ Some models are too large to fit on a single GPU, so you need distributed infere
 
 ### What’s the best way to start experimenting with inference frameworks?
 
-A good path is to begin small and level up as you go. Many people start with Ollama because it runs on a laptop with almost no setup. It’s perfect for quick tests, [prompt tinkering](../model-interaction/prompt-engineering), or getting a feel for how different models behave. Once you understand the basics and want to evaluate real performance for production, move to vLLM, SGLang, or MAX. These frameworks are built for production-level workloads, so you can measure latency, throughput, batching behavior, and GPU efficiency in a realistic environment.
+A good path is to begin small and level up as you go. Many people start with Ollama because it runs on a laptop with almost no setup. It’s perfect for quick tests, [prompt tinkering](/model-interaction/prompt-engineering/), or getting a feel for how different models behave. Once you understand the basics and want to evaluate real performance for production, move to vLLM, SGLang, or MAX. These frameworks are built for production-level workloads, so you can measure latency, throughput, batching behavior, and GPU efficiency in a realistic environment.
 
 <LinkList>
   ## Additional resources
-  * [LLM performance benchmarks](../inference-optimization/llm-performance-benchmarks)
+  * [LLM performance benchmarks](/inference-optimization/llm-performance-benchmarks/)
 </LinkList>

--- a/docs/getting-started/choosing-the-right-model.md
+++ b/docs/getting-started/choosing-the-right-model.md
@@ -38,7 +38,7 @@ Base model examples: Qwen3.5-0.8B-Base, DeepSeek-V3-Base, GPT-style pretraining 
 
 Instruction-tuned models are built on top of base models. After the initial pretraining phase, these models go through a second training stage using datasets made up of instructions and their corresponding responses.
 
-This process teaches the models how to follow user [prompts](../model-interaction/prompt-engineering) more reliably, so that they are better aligned with human expectations. They understand task intent and respond more coherently to commands like:
+This process teaches the models how to follow user [prompts](/model-interaction/prompt-engineering/) more reliably, so that they are better aligned with human expectations. They understand task intent and respond more coherently to commands like:
 
 - “Summarize this article.”
 - “Explain how LLM inference works.”
@@ -77,7 +77,7 @@ Here are common examples:
 - **Vision language models (VLMs)**. Models such as NVLM 1.0 and Qwen2.5-VL combine visual and textual understanding, supporting tasks like image captioning, visual Q&A, or reasoning over screenshots and diagrams.
 - **Text-to-speech (TTS) models**. They can convert text into natural-sounding speech. When integrated with LLMs, they can be used in voice-based agents, accessible interfaces, or immersive experiences.
 
-Learn more about [multi-model inference pipelines](../infrastructure-and-operations/multi-model-inference-pipelines).
+Learn more about [multi-model inference pipelines](/infrastructure-and-operations/multi-model-inference-pipelines/).
 
 ## Where to get models
 
@@ -87,7 +87,7 @@ Most teams today don’t train models from scratch. They pull from open model hu
 
 ### Hugging Face
 
-[Hugging Face](https://huggingface.co/models) is the default starting point for most teams. It hosts hundreds of thousands of open models across text, vision, audio, and multimodal tasks. You can find base models, instruct models, chat variants, embeddings, and diffusion models there. Hugging Face also provides many [fine-tuned](../model-preparation/llm-fine-tuning) and [quantized model](../model-preparation/llm-quantization) variants, making it easy to experiment with instruction-tuned or low-VRAM models without doing fine-tuning yourself.
+[Hugging Face](https://huggingface.co/models) is the default starting point for most teams. It hosts hundreds of thousands of open models across text, vision, audio, and multimodal tasks. You can find base models, instruct models, chat variants, embeddings, and diffusion models there. Hugging Face also provides many [fine-tuned](/model-preparation/llm-fine-tuning/) and [quantized model](/model-preparation/llm-quantization/) variants, making it easy to experiment with instruction-tuned or low-VRAM models without doing fine-tuning yourself.
 
 Why people use it:
 
@@ -108,7 +108,7 @@ In practice, this means you may need to:
 
 - Create a Hugging Face account
 - Generate an API token
-- Pass that token to your [inference framework](choosing-the-right-inference-framework) or deployment environment (e.g., via an environment variable like `HF_TOKEN`)
+- Pass that token to your [inference framework](/getting-started/choosing-the-right-inference-framework/) or deployment environment (e.g., via an environment variable like `HF_TOKEN`)
 
 Models that require gated access often come with stricter usage terms, less operational polish, or fewer guarantees around long-term availability.
 
@@ -225,7 +225,7 @@ Some LLMs have long, confusing names, but they usually encode useful information
 
 - The number usually indicates the number of parameters in the model. The letter B stands for billion parameters.
 - “Instruct” means the model has been instruction-tuned. “Chat” models are optimized for multi-turn conversations.
-- Some models have [“quantized” versions](../model-preparation/llm-quantization), meaning the model weights are compressed to reduce memory usage.
+- Some models have [“quantized” versions](/model-preparation/llm-quantization/), meaning the model weights are compressed to reduce memory usage.
 - Some model names include a year, month, or date to indicate when the model was released or updated. This helps users quickly identify the generation of the model.
 - MoE models sometimes include two numbers in their names to describe how the expert system works, such as Qwen3.5-35B-A3B. These numbers usually indicate:
   - The total number of experts

--- a/docs/getting-started/on-prem-llms.md
+++ b/docs/getting-started/on-prem-llms.md
@@ -17,7 +17,7 @@ This kind of freedom brings advantages, but also serious engineering challenges.
 AI teams usually turn to on-prem deployments for the following reasons:
 
 - **Data security and compliance**: All inference runs inside your infrastructure. This reduces the risk of sensitive information leaving your environment. It also helps you meet strict regulatory requirements in industries such as healthcare, finance, and government.
-- **Predictable costs**: After the initial hardware investment, ongoing inference costs may be lower than usage-based serverless APIs. However, you may need to apply certain inference optimization techniques like [KV cache offloading](../inference-optimization/kv-cache-offloading) and [prefix caching](../inference-optimization/prefix-caching) to stay within budget.
+- **Predictable costs**: After the initial hardware investment, ongoing inference costs may be lower than usage-based serverless APIs. However, you may need to apply certain inference optimization techniques like [KV cache offloading](/inference-optimization/kv-cache-offloading/) and [prefix caching](/inference-optimization/prefix-caching/) to stay within budget.
 - **Performance control**: You can directly tune inference performance for your latency, throughput, and scaling goals without being limited by a provider’s SLA. This is extremely useful for high-volume or latency-sensitive applications.
 - **Fewer external dependencies**: Since everything happens within your own network, you don’t have to rely on external providers. This allows you to enforce custom security measures such as authentication, access control, and auditing. This minimizes exposure to external threats.
 
@@ -54,7 +54,7 @@ No universal answer exists to whether on-prem is “better” than cloud. Each o
 | **Cost model** | High upfront hardware investment; lower marginal costs for steady traffic | Pay-per-use; flexible for bursty or unpredictable workloads |
 | **Performance control** | Full control over latency, throughput, and scaling behavior | Limited by provider SLAs and shared infrastructure |
 | **Scalability** | Limited by purchased hardware; fast autoscaling for LLMs requires extra setups and configurations | Virtually unlimited, with on-demand GPU access; however, you may also need extra tuning to speed up cold starts for LLMs |
-| **Maintenance and operations**  | Requires dedicated teams for infra, LLM-specific observability, and updates | Faster setup, but still require some infra management; [BYOC](./bring-your-own-cloud) offloads part of the burdens to service providers |
+| **Maintenance and operations**  | Requires dedicated teams for infra, LLM-specific observability, and updates | Faster setup, but still require some infra management; [BYOC](/getting-started/bring-your-own-cloud/) offloads part of the burdens to service providers |
 | **Flexibility** | Best for long-term, stable workloads | Best for rapid experimentation and dynamic workloads |
 
 The decision usually depends on compliance requirements, traffic patterns, and how much operational complexity your team is willing to manage.

--- a/docs/getting-started/serverless-vs-self-hosted-llm-inference.md
+++ b/docs/getting-started/serverless-vs-self-hosted-llm-inference.md
@@ -33,10 +33,10 @@ Key benefits of self-hosting include:
 - **Data privacy and compliance**: LLMs are widely used in modern applications like RAG and AI agents. These systems often require frequent access to sensitive data (e.g., customer details, medical records, financial information). This is often not an acceptable option for organizations in regulated industries with compliance and privacy requirements. Self-hosting LLMs makes sure your data always stays within your secure environment.
 - **Advanced customization and optimization**: With self-hosting, you can tailor your inference process to meet specific needs, such as:
     - Adjusting latency and throughput trade-offs precisely.
-    - Implementing advanced optimizations like [prefill-decode disaggregation](../inference-optimization/prefill-decode-disaggregation), [prefix caching](../inference-optimization/prefix-caching), and [speculative decoding](../inference-optimization/speculative-decoding).
-    - Optimizing for long contexts or [batch-processing](../inference-optimization/static-dynamic-continuous-batching) scenarios.
+    - Implementing advanced optimizations like [prefill-decode disaggregation](/inference-optimization/prefill-decode-disaggregation/), [prefix caching](/inference-optimization/prefix-caching/), and [speculative decoding](/inference-optimization/speculative-decoding/).
+    - Optimizing for long contexts or [batch-processing](/inference-optimization/static-dynamic-continuous-batching/) scenarios.
     - Enforcing structured decoding to ensure outputs follow strict schemas
-    - [Fine-tuning models](../model-preparation/llm-fine-tuning) using proprietary data to achieve competitive advantages.
+    - [Fine-tuning models](/model-preparation/llm-fine-tuning/) using proprietary data to achieve competitive advantages.
 - **Predictable performance and control**: When you self-host your LLMs, you have complete control over how your system behaves and performs. You’re not at the mercy of external API rate limits or sudden policy changes that might impact your application’s performance and availability.
 
 ## Comparison summary
@@ -55,7 +55,7 @@ Choosing between serverless and self-hosted LLM inference depends on your specif
 
 With serverless APIs, the cost per token is fixed, but total spend scales linearly with usage. That’s fine for early prototyping, but it becomes expensive fast in production.
 
-With self-hosting, there’s more upfront work and infrastructure cost. However, your per-token cost will drop significantly as you scale, especially using inference optimization techniques like [KV cache offloading](../inference-optimization/kv-cache-offloading).
+With self-hosting, there’s more upfront work and infrastructure cost. However, your per-token cost will drop significantly as you scale, especially using inference optimization techniques like [KV cache offloading](/inference-optimization/kv-cache-offloading/).
 
 At different stages of your AI adoption, you may want to reevaluate your approach and weigh trade-offs between agility and control.
 

--- a/docs/inference-optimization/inference-routing.md
+++ b/docs/inference-optimization/inference-routing.md
@@ -29,7 +29,7 @@ A routing decision affects things like:
 - Whether prefill or decode work is already saturating the worker
 - Whether the overall GPU pool stays busy across uneven traffic patterns
 
-Therefore, inference routing is closely tied to concepts like [prefix caching](./prefix-caching), [KV cache offloading](./kv-cache-offloading), and [prefill-decode disaggregation](./prefill-decode-disaggregation).
+Therefore, inference routing is closely tied to concepts like [prefix caching](/inference-optimization/prefix-caching/), [KV cache offloading](/inference-optimization/kv-cache-offloading/), and [prefill-decode disaggregation](/inference-optimization/prefill-decode-disaggregation/).
 
 At platform scale, routing is also an economic tool. Better placement keeps GPUs useful across heterogeneous tenants and bursty workloads, not just faster for one request.
 
@@ -50,7 +50,7 @@ LLM inference breaks those assumptions in several ways:
 
 - **Requests are not equal**. A 100-token prompt and a 100k-token prompt have completely different memory and compute footprints. Some requests finish in milliseconds, while others may generate tokens for minutes.
 - **Workers carry state**. During prefill, the model builds KV cache that can be reused by later requests. However, that reuse only happens if the next request reaches a worker that already owns the right cache. This is especially important for multi-turn chats and agent workflows where prompts often share large prefixes.
-- **Prefill and decode stress different resources**. Prefill is mostly compute-bound, while decode is usually memory-bandwidth-bound. A worker busy decoding a long output can still accept new prefill work, and vice versa. Many distributed systems separate them entirely to avoid wasted GPU cycles and memory bandwidth. See [prefill-decode disaggregation](./prefill-decode-disaggregation) to learn more.
+- **Prefill and decode stress different resources**. Prefill is mostly compute-bound, while decode is usually memory-bandwidth-bound. A worker busy decoding a long output can still accept new prefill work, and vice versa. Many distributed systems separate them entirely to avoid wasted GPU cycles and memory bandwidth. See [prefill-decode disaggregation](/inference-optimization/prefill-decode-disaggregation/) to learn more.
 - **Latency goals differ across workloads**. Code completion, chat applications, agents, and batch inference jobs all have different latency requirements. Some workloads prioritize low TTFT, while others care more about throughput or total cost. If every worker is treated identically, expensive long-running requests can interfere with latency-sensitive ones. For example, a code completion request may end up waiting behind long agent generations even though the user expects an instant response.
 
 When the router can't see these details, it starts making bad decisions, leading to:

--- a/docs/inference-optimization/llm-performance-benchmarks.md
+++ b/docs/inference-optimization/llm-performance-benchmarks.md
@@ -31,7 +31,7 @@ Here are situations where custom benchmarking makes sense:
 - **Comparing different models**. When you make a decision between two of the best LLMs, benchmarks reveal how they differ in throughput, latency, and cost under your workload.
 - **Evaluating inference frameworks**. Frameworks like vLLM, SGLang, TensorRT-LLM, and Hugging Face TGI provide different inference optimizations. Benchmarks help you see which delivers the best trade-off for your setup.
 - **Testing infrastructure changes**. Moving from A10G to H100 GPUs, or switching from on-prem to cloud, will affect performance. Benchmarks confirm the impact.
-- **Measuring optimization gains**. Inference techniques such as [speculative decoding](./speculative-decoding), [prefix caching](./prefix-caching), [disaggregated serving](./prefill-decode-disaggregation), or [KV cache offloading](./kv-cache-offloading) should always be validated with repeatable performance testing.
+- **Measuring optimization gains**. Inference techniques such as [speculative decoding](/inference-optimization/speculative-decoding/), [prefix caching](/inference-optimization/prefix-caching/), [disaggregated serving](/inference-optimization/prefill-decode-disaggregation/), or [KV cache offloading](/inference-optimization/kv-cache-offloading/) should always be validated with repeatable performance testing.
 - **Scaling for production traffic**. Before going live, benchmarks under realistic request rates and concurrency levels show how your system holds up.
 
 In short, you should run LLM performance benchmarks whenever you need evidence-based answers about which inference setup will meet your requirements.
@@ -82,7 +82,7 @@ When running performance benchmarks for LLM inference, it’s not enough to repo
 - **Throughput**: How many tokens or requests per second the model can process or produce. This measures scalability and raw efficiency.
 - **Latency**: How quickly the model responds to a request. Key latency metrics include TTFT, ITL, median latency, and tail latencies (P95, P99). These determine how responsive your LLM feels to users.
     
-  See [LLM inference metrics](../llm-inference-basics/llm-inference-metrics) for more information.
+  See [LLM inference metrics](/llm-inference-basics/llm-inference-metrics/) for more information.
     
 - **Cost**: Usually measured as cost per thousand tokens, cost per request, or cost per unit time. For self-hosted inference, GPUs are often the biggest driver of cost. Many top LLMs require large, expensive GPUs to run efficiently.
 - **Resource utilization**: GPU/CPU utilization, memory allocation, and cache hit rates. High utilization often means better hardware efficiency. This is especially important in production since it directly determines how much performance you get per dollar.

--- a/docs/inference-optimization/pagedattention.md
+++ b/docs/inference-optimization/pagedattention.md
@@ -17,9 +17,9 @@ import LinkList from '@site/src/components/LinkList';
 
 ## Why contiguous KV cache allocation wastes memory
 
-When an LLM is generating a response, it needs to [remember past information (i.e. the KV cache) for every token it generates](../llm-inference-basics/how-does-llm-inference-work#the-two-phases-of-llm-inference). Normally, the KV cache takes up a big chunk of memory because it’s stored as one giant continuous block. This can lead to memory fragmentation or wasted space because you need to reserve a big block even if you don’t fill it fully.
+When an LLM is generating a response, it needs to [remember past information (i.e. the KV cache) for every token it generates](/llm-inference-basics/how-does-llm-inference-work/#the-two-phases-of-llm-inference). Normally, the KV cache takes up a big chunk of memory because it’s stored as one giant continuous block. This can lead to memory fragmentation or wasted space because you need to reserve a big block even if you don’t fill it fully.
 
-Specifically, early serving engines often allocated KV cache as a contiguous tensor sized for the worst case. [A simplified shape](./kv-cache-offloading#how-to-calculate-the-kv-cache-size) is:
+Specifically, early serving engines often allocated KV cache as a contiguous tensor sized for the worst case. [A simplified shape](/inference-optimization/kv-cache-offloading/#how-to-calculate-the-kv-cache-size) is:
 
 ```bash
 2 × num_layers × num_heads × head_dim × max_seq_len
@@ -37,7 +37,7 @@ This saves memory and makes the whole process more efficient. It even allows the
 
 The original PagedAttention paper reports that, without PagedAttention, only 20.4%-38.2% of allocated KV cache memory is used to store actual token states, with the remainder wasted due to fragmentation. By contrast, PagedAttention reduces KV cache memory waste to nearly zero.
 
-This is why PagedAttention matters beyond a single attention kernel. It gives the serving engine a better memory allocator for KV cache, which then makes techniques like [continuous batching](./static-dynamic-continuous-batching), [prefix caching](./prefix-caching), and [KV cache offloading](./kv-cache-offloading) easier to combine.
+This is why PagedAttention matters beyond a single attention kernel. It gives the serving engine a better memory allocator for KV cache, which then makes techniques like [continuous batching](/inference-optimization/static-dynamic-continuous-batching/), [prefix caching](/inference-optimization/prefix-caching/), and [KV cache offloading](/inference-optimization/kv-cache-offloading/) easier to combine.
 
 PagedAttention was first implemented by vLLM. Since then, other projects like Hugging Face TGI and TensorRT-LLM have also adopted and implemented PagedAttention.
 

--- a/docs/inference-optimization/prefill-decode-disaggregation.md
+++ b/docs/inference-optimization/prefill-decode-disaggregation.md
@@ -16,7 +16,7 @@ import LinkList from '@site/src/components/LinkList';
 
 # Prefill-decode disaggregation
 
-To understand prefill-decode (PD) disaggregation, let’s briefly review how [LLM inference works](../llm-inference-basics/how-does-llm-inference-work) in two steps:
+To understand prefill-decode (PD) disaggregation, let’s briefly review how [LLM inference works](/llm-inference-basics/how-does-llm-inference-work/) in two steps:
 
 - **Prefill**: Processes the entire sequence in parallel and store key and value vectors from the attention layers in a KV cache. Because it’s handling all the tokens at once with large matrix operations, prefill is compute-bound, but not too demanding on GPU memory.
 - **Decode**: Generates the output tokens, one at a time, by reusing the KV cache built earlier. Each generated token requires repeatedly loading model weights and accessing an ever-growing KV cache. Therefore, decode requires fast memory access but lower compute.
@@ -60,7 +60,7 @@ As promising as PD disaggregation sounds, it’s not a one-size-fits-all fix.
   - Should KV blocks move eagerly after prefill, or lazily when decode actually needs them?
   - How does the router decide whether to reuse an existing cache, run local prefill, or send the request to a separate prefill pool?
 
-  These questions connect PD disaggregation to [KV cache offloading](./kv-cache-offloading) and [prefix caching](./prefix-caching). Treat them as parts of the same serving architecture, not isolated tuning knobs.
+  These questions connect PD disaggregation to [KV cache offloading](/inference-optimization/kv-cache-offloading/) and [prefix caching](/inference-optimization/prefix-caching/). Treat them as parts of the same serving architecture, not isolated tuning knobs.
 
 - **Cache compatibility matters**: The prefill worker and decode worker must agree on KV layout, page size, dtype, attention variant, and any extra cache metadata. Heterogeneous KV types (e.g., quantized KV caches, VLM encoder states, and speculative decoding caches) can make this handoff more complex than moving one standard full-attention KV tensor.
 

--- a/docs/inference-optimization/prefix-caching.md
+++ b/docs/inference-optimization/prefix-caching.md
@@ -68,7 +68,7 @@ The user then asks:
 User: Which lookup should we optimize first?
 ```
 
-The model isn't given only the latest question. The application resends the previous messages as part of the [context window](../llm-inference-basics/how-does-llm-inference-work#what-is-a-context-window-and-how-does-it-work-in-llm-inference), so the model knows which lookups the user means. The serialized second request therefore looks roughly like this:
+The model isn't given only the latest question. The application resends the previous messages as part of the [context window](/llm-inference-basics/how-does-llm-inference-work/#what-is-a-context-window-and-how-does-it-work-in-llm-inference), so the model knows which lookups the user means. The serialized second request therefore looks roughly like this:
 
 ```bash
 User: Why did the checkout API slow down after deployment?
@@ -78,7 +78,7 @@ User: Which lookup should we optimize first?
 
 The first two messages are an exact prefix that the model has already processed. If their KV states are still available, the model can reuse them and prefill only the new user message. Without prefix caching, it must process the entire conversation again.
 
-As the conversation grows, the reusable prefix grows with it. Avoiding repeated prefill reduces GPU compute and keeps TTFT from rising as quickly across turns. Note that a cache hit still depends on the serving engine retaining the entry, [routing the request to a worker that can access the cache](inference-routing), and serializing the previous messages identically.
+As the conversation grows, the reusable prefix grows with it. Avoiding repeated prefill reduces GPU compute and keeps TTFT from rising as quickly across turns. Note that a cache hit still depends on the serving engine retaining the entry, [routing the request to a worker that can access the cache](/inference-optimization/inference-routing/), and serializing the previous messages identically.
 
 ## What is the difference between KV caching and prefix caching?
 

--- a/docs/inference-optimization/prefix-caching.md
+++ b/docs/inference-optimization/prefix-caching.md
@@ -71,9 +71,9 @@ In agent workflows, the benefit is even more pronounced. Some use cases have inp
 
 For applications with long, repetitive prompts, prefix caching can significantly reduce both latency and cost. Over time, however, your KV cache size can be quite large. GPU memory is finite, and storing long prefixes across many users can eat up space quickly. You’ll need cache eviction strategies or memory tiering.
 
-The open-source community is actively working on distributed serving strategies. See [inference routing](./inference-routing) for details.
+The open-source community is actively working on distributed serving strategies. See [inference routing](/inference-optimization/inference-routing/) for details.
 
-Another practical limitation is feature composition. Prefix caching is easy to reason about when the model has one standard full-attention KV cache. Newer serving stacks may need to manage several cache-like states at once: draft and target model caches for [speculative decoding](./speculative-decoding), image encoder states for VLMs, scaling metadata for quantized KV cache, or separate caches for hybrid attention layers.
+Another practical limitation is feature composition. Prefix caching is easy to reason about when the model has one standard full-attention KV cache. Newer serving stacks may need to manage several cache-like states at once: draft and target model caches for [speculative decoding](/inference-optimization/speculative-decoding/), image encoder states for VLMs, scaling metadata for quantized KV cache, or separate caches for hybrid attention layers.
 
 For these models, a shared text prefix does not always mean every cached state can be reused in the same way. Sliding-window attention, for example, only keeps a bounded recent window, so the cache manager must know which tokens are still valid. In production, treat prefix cache hit rate as a per-workload metric rather than a single global number, and verify that your inference framework can compose prefix caching with the other optimizations you enable.
 

--- a/docs/inference-optimization/speculative-decoding.md
+++ b/docs/inference-optimization/speculative-decoding.md
@@ -23,11 +23,11 @@ This draft-then-verify pattern guarantees the final output matches exactly what 
 
 ## Why speculative decoding
 
-[Transformer-based LLMs generate text autoregressively](../llm-inference-basics/how-does-llm-inference-work#the-two-phases-of-llm-inference): one token at a time, each depending on the previous ones. Every new token requires a full forward pass, sampling, and then appending that token to the input before the next step begins.
+[Transformer-based LLMs generate text autoregressively](/llm-inference-basics/how-does-llm-inference-work/#the-two-phases-of-llm-inference): one token at a time, each depending on the previous ones. Every new token requires a full forward pass, sampling, and then appending that token to the input before the next step begins.
 
 This sequential process has two major issues:
 
-- **High Inter-Token Latency (ITL)**: [The delay between tokens](../llm-inference-basics/llm-inference-metrics) makes generation feel slow.
+- **High Inter-Token Latency (ITL)**: [The delay between tokens](/llm-inference-basics/llm-inference-metrics/) makes generation feel slow.
 - **Poor GPU utilization**: The model can’t compute future tokens in advance even if the GPU is idle.
 
 What if you could parallelize parts of the generation process, even if not all of it?
@@ -55,7 +55,7 @@ At a high level, speculative decoding runs in a loop:
 
 ## Understanding the performance of speculative decoding
 
-Speculative decoding can accelerate LLM inference, but only when the draft and target models align well. Before enabling it in production, always benchmark performance under your workload. For a quick test, you can choose [inference frameworks](../getting-started/choosing-the-right-inference-framework) like vLLM and SGLang, which provide built-in support for this inference optimization technique.
+Speculative decoding can accelerate LLM inference, but only when the draft and target models align well. Before enabling it in production, always benchmark performance under your workload. For a quick test, you can choose [inference frameworks](/getting-started/choosing-the-right-inference-framework/) like vLLM and SGLang, which provide built-in support for this inference optimization technique.
 
 ### Key metrics
 

--- a/docs/inference-optimization/static-dynamic-continuous-batching.md
+++ b/docs/inference-optimization/static-dynamic-continuous-batching.md
@@ -59,7 +59,7 @@ Continuous batching, also known as in-flight batching, addresses these inefficie
 
 This technique uses iteration-level scheduling, meaning the batch composition changes dynamically at each decoding iteration. As soon as a sequence in the batch finishes generating tokens, the server inserts a new request in its place. This maximizes GPU occupancy and keeps compute resources busy by avoiding idle time that would otherwise be spent waiting for the slowest sequence in a batch to finish.
 
-Major [inference frameworks](../getting-started/choosing-the-right-inference-framework) such as vLLM, SGLang, TensorRT-LLM (in-flight batching) and LMDeploy (persistent batching) all support continuous batching or similar mechanisms. For memory management in long or mixed-length batches, see [PagedAttention](./pagedattention).
+Major [inference frameworks](/getting-started/choosing-the-right-inference-framework/) such as vLLM, SGLang, TensorRT-LLM (in-flight batching) and LMDeploy (persistent batching) all support continuous batching or similar mechanisms. For memory management in long or mixed-length batches, see [PagedAttention](/inference-optimization/pagedattention/).
 
 ## Chunked prefill
 
@@ -69,7 +69,7 @@ Continuous batching introduces a scheduling conflict when a new request arrives 
 
 <ChunkedPrefillVisualizer />
 
-The scheduler can combine one prefill chunk with decode tokens from active requests in the same batch. [SARATHI](https://arxiv.org/abs/2308.16369) calls this **decode-maximal batching**: the prefill chunk supplies enough parallel work to saturate the compute capacity of the GPU, while decode tokens piggyback on the same model execution at little extra cost. This prevents a long prompt from monopolizing one iteration and can also reduce pipeline bubbles under [pipeline parallelism](./data-tensor-pipeline-expert-hybrid-parallelism#pipeline-parallelism).
+The scheduler can combine one prefill chunk with decode tokens from active requests in the same batch. [SARATHI](https://arxiv.org/abs/2308.16369) calls this **decode-maximal batching**: the prefill chunk supplies enough parallel work to saturate the compute capacity of the GPU, while decode tokens piggyback on the same model execution at little extra cost. This prevents a long prompt from monopolizing one iteration and can also reduce pipeline bubbles under [pipeline parallelism](/inference-optimization/data-tensor-pipeline-expert-hybrid-parallelism/#pipeline-parallelism).
 
 The benefit of chunked prefill is that even when a request has a long prompt, the prefill computation is divided into smaller chunks. Instead of waiting for one long prefill iteration to finish, active decode requests can continue generating tokens between prefill chunks. This reduces Inter-Token Latency (ITL) and makes streamed responses smoother.
 
@@ -106,7 +106,7 @@ The shorter sequences may be padded to length `1024`. That keeps the tensor shap
 
 ### What are ragged tensors in LLM inference?
 
-Ragged tensors represent variable-length sequences without padding them all to one fixed length. Instead, the runtime stores the real tokens plus metadata such as sequence lengths, offsets, or KV cache block locations. This helps inference engines handle mixed-length prompts and continuous batching more efficiently, especially when paired with paged KV cache layouts such as [PagedAttention](./pagedattention).
+Ragged tensors represent variable-length sequences without padding them all to one fixed length. Instead, the runtime stores the real tokens plus metadata such as sequence lengths, offsets, or KV cache block locations. This helps inference engines handle mixed-length prompts and continuous batching more efficiently, especially when paired with paged KV cache layouts such as [PagedAttention](/inference-optimization/pagedattention/).
 
 <LinkList>
   ## Additional resources

--- a/docs/infrastructure-and-operations/build-and-maintenance-cost.md
+++ b/docs/infrastructure-and-operations/build-and-maintenance-cost.md
@@ -19,7 +19,7 @@ LLM inference requires much more than standard cloud-native stacks can provide. 
 - Provisioning high-performance GPUs (often scarce and regionally limited)
 - Managing CUDA version compatibility and driver dependencies
 - Configuring autoscaling, concurrency control, and scale-to-zero behavior
-- Applying advanced inference optimization techniques such as [prefix caching](../inference-optimization/prefix-caching) and [prefill-decode disaggregation](../inference-optimization/prefill-decode-disaggregation)
+- Applying advanced inference optimization techniques such as [prefix caching](/inference-optimization/prefix-caching/) and [prefill-decode disaggregation](/inference-optimization/prefill-decode-disaggregation/)
 - Setting up observability tools for GPU monitoring, request tracing, and failure detection
 - Handling model-specific behaviors like streaming, caching, and routing
 

--- a/docs/infrastructure-and-operations/distributed-inference.md
+++ b/docs/infrastructure-and-operations/distributed-inference.md
@@ -21,7 +21,7 @@ On the macro level, distributed inference refers to high-level deployment and to
 
 - Running a model, or multiple replicas of it, across multiple geographic regions
 - Serving traffic on heterogeneous GPU clusters with different hardware profiles
-- Orchestrating inference across [multiple cloud (or NeoCloud) providers](./multi-cloud-and-cross-region-inference), and [on-prem data centers](../getting-started/on-prem-llms)
+- Orchestrating inference across [multiple cloud (or NeoCloud) providers](/infrastructure-and-operations/multi-cloud-and-cross-region-inference/), and [on-prem data centers](/getting-started/on-prem-llms/)
 
 At this level, teams distribute inference geographically to reduce latency, meet data residency requirements, improve fault tolerance, or take advantage of cheaper or more available GPU capacity in specific regions.
 
@@ -37,10 +37,10 @@ These techniques focus on parallelizing the internal mechanics of inference itse
 
 Common examples include:
 
-- [Prefill–decode disaggregation](../inference-optimization/prefill-decode-disaggregation). Separating prefill and decode work so each stage can run on specialized hardware.
-- [KV cache offloading](../inference-optimization/kv-cache-offloading). Moving KV cache data to CPU memory or remote storage to reduce GPU memory pressure and compute costs.
-- [Inference routing](../inference-optimization/inference-routing). Routing a request to the worker that holds useful cache or has enough capacity, reducing recomputation and improving throughput.
-- [Parallelism](../inference-optimization/data-tensor-pipeline-expert-hybrid-parallelism). Splitting a large model across multiple GPUs when it cannot fit on a single device. This can take several forms, such as single-node multi-GPU and multi-node multi-GPU.
+- [Prefill–decode disaggregation](/inference-optimization/prefill-decode-disaggregation/). Separating prefill and decode work so each stage can run on specialized hardware.
+- [KV cache offloading](/inference-optimization/kv-cache-offloading/). Moving KV cache data to CPU memory or remote storage to reduce GPU memory pressure and compute costs.
+- [Inference routing](/inference-optimization/inference-routing/). Routing a request to the worker that holds useful cache or has enough capacity, reducing recomputation and improving throughput.
+- [Parallelism](/inference-optimization/data-tensor-pipeline-expert-hybrid-parallelism/). Splitting a large model across multiple GPUs when it cannot fit on a single device. This can take several forms, such as single-node multi-GPU and multi-node multi-GPU.
 
 Micro-level distributed inference is mainly about how inference runs efficiently, independent of where the infrastructure is deployed.
 
@@ -141,7 +141,7 @@ Teams often struggle with:
 - Attributing cost to specific models, workloads, or tenants
 - Detecting inefficiencies such as idle GPUs or imbalanced traffic
 
-Without [centralized observability](./comprehensive-observability) and cost visibility, distributed inference systems can become opaque. This makes it difficult to optimize performance and troubleshoot issues.
+Without [centralized observability](/infrastructure-and-operations/comprehensive-observability/) and cost visibility, distributed inference systems can become opaque. This makes it difficult to optimize performance and troubleshoot issues.
 
 ### State management and consistency
 
@@ -175,7 +175,7 @@ A naive round-robin scheduler quickly breaks down at scale. Modern inference sys
 
 ### Distributed inference runtimes
 
-Most teams do not build distributed inference from scratch. Instead, they rely on specialized runtimes that implement core [inference techniques](../inference-optimization/) such as parallelism and prefix-aware routing.
+Most teams do not build distributed inference from scratch. Instead, they rely on specialized runtimes that implement core [inference techniques](/inference-optimization/) such as parallelism and prefix-aware routing.
 
 In practice, teams often run inference runtimes such as vLLM, SGLang, and llm-d on Kubernetes. To some extent, they do help handle how inference runs at the micro level, but they do not fully solve macro-level concerns for LLM workloads such as multi-region routing, autoscaling, or operational visibility.
 
@@ -185,7 +185,7 @@ To run distributed inference in production, teams must also integrate:
 
 - Autoscaling policies across GPU pools
 - Health checks and failure recovery
-- Unified observability for [latency (e.g., TTFT and ITL)](../llm-inference-basics/llm-inference-metrics), throughput, GPU utilization, and errors
+- Unified observability for [latency (e.g., TTFT and ITL)](/llm-inference-basics/llm-inference-metrics/), throughput, GPU utilization, and errors
 - Cost attribution across models, regions, and workloads
 
 This orchestration layer is often where most engineering effort goes, especially when operating across multiple clusters or clouds.
@@ -197,7 +197,7 @@ For many teams, building and maintaining all of these layers internally becomes 
 Our Inference Platform provides a production-ready foundation for distributed inference, integrating:
 
 - Intelligent request routing and scheduling
-- Advanced inference optimization techniques like [prefill-decode disaggregation](../inference-optimization/prefill-decode-disaggregation)
+- Advanced inference optimization techniques like [prefill-decode disaggregation](/inference-optimization/prefill-decode-disaggregation/)
 - Multi-GPU, cross-region, and multi-cloud deployment
 - Autoscaling, fault tolerance, and unified observability
 

--- a/docs/infrastructure-and-operations/multi-cloud-and-cross-region-inference.md
+++ b/docs/infrastructure-and-operations/multi-cloud-and-cross-region-inference.md
@@ -23,7 +23,7 @@ Multi-cloud inference means running LLM workloads across more than one cloud pro
 Cross-region inference refers to running LLM workloads across multiple geographic regions within the same cloud provider. Note that this doesn’t mean running a different model in each region. Instead, the same application is replicated across multiple sites so requests can be served from the nearest or most available location. For instance, a deployment might run in AWS us-east-1 for North America, eu-west-1 for Europe, and ap-southeast-1 for Asia.
 
 :::note
-Another pattern is hybrid cloud inference, which combines on-premises infrastructure with public and private cloud deployments. Instead of choosing one or the other, enterprises run part of their LLM workloads in private data centers and extend to the cloud when needed. Refer to [on-prem LLM deployments](../getting-started/on-prem-llms) for details.
+Another pattern is hybrid cloud inference, which combines on-premises infrastructure with public and private cloud deployments. Instead of choosing one or the other, enterprises run part of their LLM workloads in private data centers and extend to the cloud when needed. Refer to [on-prem LLM deployments](/getting-started/on-prem-llms/) for details.
 :::
 
 ## Why multi-cloud and cross-region inference matters
@@ -36,7 +36,7 @@ Unlike training, LLM inference is driven by real-time usage, often bursty and ha
 
 Multi-cloud and cross-region deployments provide headroom to absorb these bursts. If one region runs out of compute capacity, traffic can shift to elsewhere. If a cloud provider experiences shortages, workloads can overflow to another.
 
-For LLMs, this flexibility is especially important because inference isn’t just CPU-bound or storage-bound. It depends heavily on [GPU](../getting-started/choosing-the-right-gpu) availability. Frontier models like DeepSeek-V3.1 and gpt-oss-120b require hardware such as NVIDIA H100s and AMD MI300Xs, which are both expensive and limited. 
+For LLMs, this flexibility is especially important because inference isn’t just CPU-bound or storage-bound. It depends heavily on [GPU](/getting-started/choosing-the-right-gpu/) availability. Frontier models like DeepSeek-V3.1 and gpt-oss-120b require hardware such as NVIDIA H100s and AMD MI300Xs, which are both expensive and limited. 
 
 With a multi-cloud or cross-region setup, you increase the chance of finding GPUs when you need them. As such, teams can smooth out traffic spikes, avoid dropped requests, and maintain a consistent experience as they to scale.
 

--- a/docs/infrastructure-and-operations/multi-model-inference-pipelines.md
+++ b/docs/infrastructure-and-operations/multi-model-inference-pipelines.md
@@ -14,7 +14,7 @@ import LinkList from '@site/src/components/LinkList';
 
 A multi-model inference pipeline is a system where several models work together to produce one result. Instead of asking a single model to do everything, you split the work into stages. Each stage focuses on a specific task, like retrieval, OCR, classification, generation, or post-processing.
 
-This is different from running one model behind a single endpoint. It’s also different from [pipeline parallelism](../inference-optimization/data-tensor-pipeline-expert-hybrid-parallelism), which splits one model across multiple devices. Here, the main question is not how to distribute one model. It is how to design, deploy, and operate a system where several models cooperate in one request path.
+This is different from running one model behind a single endpoint. It’s also different from [pipeline parallelism](/inference-optimization/data-tensor-pipeline-expert-hybrid-parallelism/), which splits one model across multiple devices. Here, the main question is not how to distribute one model. It is how to design, deploy, and operate a system where several models cooperate in one request path.
 
 ## What a multi-model pipeline looks like
 
@@ -88,7 +88,7 @@ That division of labor is often more effective than forcing one model to stretch
 
 Not every stage deserves the same hardware.
 
-A lightweight preprocessing or validation stage may run well on CPU. A vision encoder, reranker, or large generator may need [high-performance GPUs](../getting-started/choosing-the-right-gpu). Some stages batch nicely, while others are highly latency-sensitive and should stay small and fast.
+A lightweight preprocessing or validation stage may run well on CPU. A vision encoder, reranker, or large generator may need [high-performance GPUs](/getting-started/choosing-the-right-gpu/). Some stages batch nicely, while others are highly latency-sensitive and should stay small and fast.
 
 This lets teams place each stage on the hardware that matches its workload instead of overprovisioning the whole pipeline around the most expensive stage.
 
@@ -126,7 +126,7 @@ Model composition comes with a real tax:
 
 - More services to deploy
 - More contracts between stages
-- More [observability](./comprehensive-observability) work
+- More [observability](/infrastructure-and-operations/comprehensive-observability/) work
 - More failure modes
 - More tuning at the end-to-end level
 
@@ -160,7 +160,7 @@ A document workflow might look like this:
 Document image → OCR → Layout extraction → Classify → Summarize → Structured Output
 ```
 
-This is hard to replace with one model if accuracy, formatting, or traceability matters. OCR and layout extraction are very different tasks from summarization. The trade-off is that large intermediate artifacts can move across several stages, so payload design matters. If the output needs to feed another system directly, [structured outputs](../model-interaction/structured-outputs) can make that handoff much easier to maintain.
+This is hard to replace with one model if accuracy, formatting, or traceability matters. OCR and layout extraction are very different tasks from summarization. The trade-off is that large intermediate artifacts can move across several stages, so payload design matters. If the output needs to feed another system directly, [structured outputs](/model-interaction/structured-outputs/) can make that handoff much easier to maintain.
 
 ### Multimodal assistant
 
@@ -184,7 +184,7 @@ There is no universal winner. The right choice depends on what constraint matter
 
 As a rule of thumb:
 
-- Start with one model if it already meets your product requirement. Learn how to [choose the right model](../getting-started/choosing-the-right-model) before you decide to compose several models.
+- Start with one model if it already meets your product requirement. Learn how to [choose the right model](/getting-started/choosing-the-right-model/) before you decide to compose several models.
 - Add stages when they clearly help
 - Keep the number of stages as small as possible
 
@@ -204,7 +204,7 @@ They can reduce cost when small specialist models filter or route requests befor
 
 ### How is this different from an agentic workflow?
 
-Both chain multiple model calls, but a multi-model pipeline is a mostly fixed graph that you design up front. An agent decides dynamically which tools or models to call, how many times, and in what order. Agents are a superset of the pipeline idea, with more flexibility and more variance in latency and cost. If you want the stage interfaces in either setup to stay predictable, [function calling](../model-interaction/function-calling) and [structured outputs](../model-interaction/structured-outputs) are often part of the solution.
+Both chain multiple model calls, but a multi-model pipeline is a mostly fixed graph that you design up front. An agent decides dynamically which tools or models to call, how many times, and in what order. Agents are a superset of the pipeline idea, with more flexibility and more variance in latency and cost. If you want the stage interfaces in either setup to stay predictable, [function calling](/model-interaction/function-calling/) and [structured outputs](/model-interaction/structured-outputs/) are often part of the solution.
 
 <LinkList>
   ## Additional resources

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -17,7 +17,7 @@ import StackQuiz from '@site/src/components/StackQuiz';
 
 # LLM Inference Handbook
 
-_LLM Inference Handbook_ is your technical glossary, guidebook, and reference - all in one. It covers everything you need to know about LLM inference, from core concepts and performance metrics (e.g., [Time to First Token and Tokens per Second](/llm-inference-basics/llm-inference-metrics)), to optimization techniques (e.g., [continuous batching](/inference-optimization/static-dynamic-continuous-batching) and [prefix caching](/inference-optimization/prefix-caching)), [GPU architecture](./kernel-optimization/gpu-architecture-fundamentals), and deployment patterns like [BYOC](./getting-started/bring-your-own-cloud) and [on-prem](./getting-started/on-prem-llms).
+_LLM Inference Handbook_ is your technical glossary, guidebook, and reference - all in one. It covers everything you need to know about LLM inference, from core concepts and performance metrics (e.g., [Time to First Token and Tokens per Second](/llm-inference-basics/llm-inference-metrics/)), to optimization techniques (e.g., [continuous batching](/inference-optimization/static-dynamic-continuous-batching/) and [prefix caching](/inference-optimization/prefix-caching/)), [GPU architecture](/kernel-optimization/gpu-architecture-fundamentals/), and deployment patterns like [BYOC](/getting-started/bring-your-own-cloud/) and [on-prem](/getting-started/on-prem-llms/).
 
 <Features>
   - Practical guidance for deploying, scaling, and operating LLMs in production.
@@ -30,7 +30,7 @@ _LLM Inference Handbook_ is your technical glossary, guidebook, and reference - 
 
 We wrote this handbook to solve a common problem facing developers: LLM inference knowledge is often fragmented; it’s buried in academic papers, scattered across vendor blogs, hidden in GitHub issues, or tossed around in Discord threads. Worse, much of it assumes you already understand half the stack.
 
-There aren’t many resources that bring it all together — like how [inference differs from training](/llm-inference-basics/training-inference-differences), why [goodput matters more than raw throughput](/llm-inference-basics/llm-inference-metrics#goodput) for meeting SLOs, or how [prefill-decode disaggregation](/inference-optimization/prefill-decode-disaggregation) works in practice.
+There aren’t many resources that bring it all together — like how [inference differs from training](/llm-inference-basics/training-inference-differences/), why [goodput matters more than raw throughput](/llm-inference-basics/llm-inference-metrics/#goodput) for meeting SLOs, or how [prefill-decode disaggregation](/inference-optimization/prefill-decode-disaggregation/) works in practice.
 
 So we started pulling it all together.
 
@@ -50,21 +50,21 @@ You can read it start-to-finish or treat it like a lookup table. There’s no wr
 
 This handbook provides various interactive tools to help you learn by trying the concepts directly:
 
-- [LLM Inference Visualizer](/llm-inference-basics/what-is-llm-inference): Walk through the request lifecycle and see how tokens flow through prefill and decode.
-- [LLM Lifecycle Visualizer](/llm-inference-basics/training-inference-differences): See where training and inference sit in the model lifecycle, and how inference runs on every request.
-- [Token-by-Token Decode Loop](/llm-inference-basics/how-does-llm-inference-work#decode): Step through autoregressive decoding and watch each new token extend the sequence and KV cache.
-- [Latency Timeline Visualizer](/llm-inference-basics/how-does-llm-inference-work#decode): See how every decode step is followed by detokenization, and which stages TTFT, ITL, and E2EL span.
-- [Context Window Simulator](/llm-inference-basics/how-does-llm-inference-work#what-is-a-context-window-and-how-does-it-work-in-llm-inference): See how the full conversation is re-sent each turn and fills the context window.
-- [Latency Metrics Playground](/llm-inference-basics/llm-inference-metrics#latency): Explore TTFT, E2EL, TPOT, and SLO-based goodput.
-- [Top-p vs Top-k Filter](/model-interaction/inference-parameters#top-p-and-top-k-sampling): Compare how each filter handles peaky, mixed, and flat distributions.
-- [Model Explorer](/getting-started/choosing-the-right-model): Browse popular open-source LLMs and compare their architecture, scale, context, and typical GPU deployment.
-- [GPU Comparison Table](/getting-started/choosing-the-right-gpu#matching-gpus-to-open-source-llms): Match popular open-source LLMs to suitable NVIDIA and AMD GPUs.
-- [GPU Memory Calculator](/getting-started/calculating-gpu-memory-for-llms#): Estimate VRAM requirements for serving an LLM.
-- [Quantization Memory Impact Visualizer](/model-preparation/llm-quantization#quantization-formats): Compare weight memory across quantization formats.
-- [Batching Strategy Simulator](/inference-optimization/static-dynamic-continuous-batching): Compare static, dynamic, and continuous batching behavior.
-- [Chunked Prefill Scheduler](/inference-optimization/static-dynamic-continuous-batching#chunked-prefill): See how a whole prefill stalls active decodes, and how chunking lets them continue.
-- [KV Cache Memory Calculator](/inference-optimization/kv-cache-offloading#how-to-calculate-the-kv-cache-size): Estimate how much memory the KV cache consumes.
-- [GPU Execution and Memory Map](/kernel-optimization/gpu-architecture-fundamentals): Visualize how threads, warps, SMs, and the GPU memory hierarchy fit together.
+- [LLM Inference Visualizer](/llm-inference-basics/what-is-llm-inference/): Walk through the request lifecycle and see how tokens flow through prefill and decode.
+- [LLM Lifecycle Visualizer](/llm-inference-basics/training-inference-differences/): See where training and inference sit in the model lifecycle, and how inference runs on every request.
+- [Token-by-Token Decode Loop](/llm-inference-basics/how-does-llm-inference-work/#decode): Step through autoregressive decoding and watch each new token extend the sequence and KV cache.
+- [Latency Timeline Visualizer](/llm-inference-basics/how-does-llm-inference-work/#decode): See how every decode step is followed by detokenization, and which stages TTFT, ITL, and E2EL span.
+- [Context Window Simulator](/llm-inference-basics/how-does-llm-inference-work/#what-is-a-context-window-and-how-does-it-work-in-llm-inference): See how the full conversation is re-sent each turn and fills the context window.
+- [Latency Metrics Playground](/llm-inference-basics/llm-inference-metrics/#latency): Explore TTFT, E2EL, TPOT, and SLO-based goodput.
+- [Top-p vs Top-k Filter](/model-interaction/inference-parameters/#top-p-and-top-k-sampling): Compare how each filter handles peaky, mixed, and flat distributions.
+- [Model Explorer](/getting-started/choosing-the-right-model/): Browse popular open-source LLMs and compare their architecture, scale, context, and typical GPU deployment.
+- [GPU Comparison Table](/getting-started/choosing-the-right-gpu/#matching-gpus-to-open-source-llms): Match popular open-source LLMs to suitable NVIDIA and AMD GPUs.
+- [GPU Memory Calculator](/getting-started/calculating-gpu-memory-for-llms/#): Estimate VRAM requirements for serving an LLM.
+- [Quantization Memory Impact Visualizer](/model-preparation/llm-quantization/#quantization-formats): Compare weight memory across quantization formats.
+- [Batching Strategy Simulator](/inference-optimization/static-dynamic-continuous-batching/): Compare static, dynamic, and continuous batching behavior.
+- [Chunked Prefill Scheduler](/inference-optimization/static-dynamic-continuous-batching/#chunked-prefill): See how a whole prefill stalls active decodes, and how chunking lets them continue.
+- [KV Cache Memory Calculator](/inference-optimization/kv-cache-offloading/#how-to-calculate-the-kv-cache-size): Estimate how much memory the KV cache consumes.
+- [GPU Execution and Memory Map](/kernel-optimization/gpu-architecture-fundamentals/): Visualize how threads, warps, SMs, and the GPU memory hierarchy fit together.
 
 ## Contributing
 

--- a/docs/kernel-optimization/flashattention.md
+++ b/docs/kernel-optimization/flashattention.md
@@ -21,7 +21,7 @@ When an LLM reads text, it has to look at every token and compare it with every 
 
 The standard attention mechanism has a fundamental problem: **it's memory-bound rather than compute-bound**. To understand this, we need to look at what happens during attention computation.
 
-If you want the lower-level GPU context behind ideas like HBM, SRAM, warps, and tiling, see [GPU architecture fundamentals](./gpu-architecture-fundamentals).
+If you want the lower-level GPU context behind ideas like HBM, SRAM, warps, and tiling, see [GPU architecture fundamentals](/kernel-optimization/gpu-architecture-fundamentals/).
 
 Standard attention calculates:
 
@@ -72,7 +72,7 @@ FlashAttention speeds up attention by reducing memory traffic. The core idea is 
 
 Simply put, FlashAttention makes the attention computation more efficient. It reorganizes the work so the GPU spends less time waiting on memory and more time doing actual computation.
 
-For a broader view of where Triton, CUDA, compiler stacks, and profiling tools fit into this kind of work, see [Kernel optimization tools](./kernel-optimization-tools).
+For a broader view of where Triton, CUDA, compiler stacks, and profiling tools fit into this kind of work, see [Kernel optimization tools](/kernel-optimization/kernel-optimization-tools/).
 
 ## The benefits of FlashAttention
 

--- a/docs/kernel-optimization/kernel-optimization-for-llm-inference.md
+++ b/docs/kernel-optimization/kernel-optimization-for-llm-inference.md
@@ -51,7 +51,7 @@ At a high level, there are two common approaches to kernel optimization dependin
 
 ## What kernel optimization is not
 
-It’s easy to mix it up with other optimization techniques covered in the [Inference Optimization](../inference-optimization/) chapter. Kernel optimization is not:
+It’s easy to mix it up with other optimization techniques covered in the [Inference Optimization](/inference-optimization/) chapter. Kernel optimization is not:
 
 - Continuous or dynamic batching
 - Prefix caching

--- a/docs/kernel-optimization/kernel-optimization-tools.md
+++ b/docs/kernel-optimization/kernel-optimization-tools.md
@@ -250,9 +250,9 @@ fn syncwarp(mask: Int = -1):
     @parameter
     if is_nvidia_gpu():
         __mlir_op.`nvvm.bar.warp.sync`(
-            __mlir_op.`index.casts`[_type = __mlir_type.i32](/kernel-optimization/
+            __mlir_op.`index.casts`[_type = __mlir_type.i32](
                 mask._mlir_value
-            /)
+            )
         )
     elif is_amd_gpu():
         # In AMD GPU this is a nop (everything executed in lock-step).

--- a/docs/kernel-optimization/kernel-optimization-tools.md
+++ b/docs/kernel-optimization/kernel-optimization-tools.md
@@ -250,9 +250,9 @@ fn syncwarp(mask: Int = -1):
     @parameter
     if is_nvidia_gpu():
         __mlir_op.`nvvm.bar.warp.sync`(
-            __mlir_op.`index.casts`[_type = __mlir_type.i32](
+            __mlir_op.`index.casts`[_type = __mlir_type.i32](/kernel-optimization/
                 mask._mlir_value
-            )
+            /)
         )
     elif is_amd_gpu():
         # In AMD GPU this is a nop (everything executed in lock-step).

--- a/docs/llm-inference-basics/cpu-vs-gpu-vs-tpu.md
+++ b/docs/llm-inference-basics/cpu-vs-gpu-vs-tpu.md
@@ -19,7 +19,7 @@ Central Processing Units (CPUs) are general-purpose processors used in all compu
 
 Graphics Processing Units (GPUs) were originally designed for graphics rendering and digital visualization tasks. As they could perform highly parallel operations, they also turned out to be a great fit for ML and AI workloads. Today, GPUs are the default choice for both training and inference of GenAI like LLMs.
 
-[The architecture of GPUs](../kernel-optimization/gpu-architecture-fundamentals) is optimized for matrix multiplication and tensor operations, which are core components of transformer-based models. Modern inference frameworks and runtimes (e.g., vLLM, SGLang, LMDeploy, TensorRT-LLM, and Hugging Face TGI) are designed to take full advantage of GPU acceleration.
+[The architecture of GPUs](/kernel-optimization/gpu-architecture-fundamentals/) is optimized for matrix multiplication and tensor operations, which are core components of transformer-based models. Modern inference frameworks and runtimes (e.g., vLLM, SGLang, LMDeploy, TensorRT-LLM, and Hugging Face TGI) are designed to take full advantage of GPU acceleration.
 
 ## TPUs
 
@@ -50,14 +50,14 @@ Here is a side-by-side comparison:
 
 Selecting the appropriate hardware requires you to understand your model size, inference volume, latency requirements, cost constraints, and available infrastructure. GPUs remain the most popular choice due to their versatility and broad support, while TPUs offer compelling advantages for certain specialized scenarios, and CPUs still have a place for lightweight, budget-conscious workloads.
 
-Learn more about [GPU choices](../getting-started/choosing-the-right-gpu) for different open-source LLMs.
+Learn more about [GPU choices](/getting-started/choosing-the-right-gpu/) for different open-source LLMs.
 
 ## Choosing the right deployment pattern
 
 The deployment pattern shapes everything from latency and scalability to privacy and cost. Each pattern suits different operational needs for enterprises.
 
 - **Cloud**: The cloud is the most popular environment for LLM inference today. It offers on-demand access to high-performance GPUs and TPUs, along with a rich ecosystem of managed services, autoscaling, and monitoring tools.
-- **Multi-cloud and cross-region**: [This flexible deployment strategy](../infrastructure-and-operations/multi-cloud-and-cross-region-inference) distributes LLM workloads across multiple cloud providers or geographic regions. It helps reduce latency for global users, improves GPU availability, optimizes compute costs, mitigates vendor lock-in, and supports compliance with data residency requirements.
-- **Bring Your Own Cloud (BYOC)**: [BYOC deployments](../getting-started/bring-your-own-cloud) let you run vendor software, such as an LLM inference platform, directly inside your own cloud account. This model combines managed orchestration with full data, network, and cost control. It's ideal for enterprises that need compliance, cost-efficiency, and scalability without full self-hosting.
-- **On-prem**: [On-premises deployments](../getting-started/on-prem-llms) mean running LLM inference on your own infrastructure, typically within a private data center. This pattern offers full control over data, performance, and compliance, but requires more operational overhead.
+- **Multi-cloud and cross-region**: [This flexible deployment strategy](/infrastructure-and-operations/multi-cloud-and-cross-region-inference/) distributes LLM workloads across multiple cloud providers or geographic regions. It helps reduce latency for global users, improves GPU availability, optimizes compute costs, mitigates vendor lock-in, and supports compliance with data residency requirements.
+- **Bring Your Own Cloud (BYOC)**: [BYOC deployments](/getting-started/bring-your-own-cloud/) let you run vendor software, such as an LLM inference platform, directly inside your own cloud account. This model combines managed orchestration with full data, network, and cost control. It's ideal for enterprises that need compliance, cost-efficiency, and scalability without full self-hosting.
+- **On-prem**: [On-premises deployments](/getting-started/on-prem-llms/) mean running LLM inference on your own infrastructure, typically within a private data center. This pattern offers full control over data, performance, and compliance, but requires more operational overhead.
 - **Edge**: In edge deployments, the model runs directly on user devices or local edge nodes, closer to where data is generated. This reduces network latency and increases data privacy, especially for time-sensitive or offline use cases. Edge inference usually uses smaller, optimized models due to limited compute resources.

--- a/docs/llm-inference-basics/how-does-llm-inference-work.md
+++ b/docs/llm-inference-basics/how-does-llm-inference-work.md
@@ -51,7 +51,7 @@ During the prefill stage, the entire prompt (namely, the whole sequence of input
 
 As a result, the prefill stage is compute-bound and often saturates GPU utilization. The actual utilization depends on factors like sequence length, batch size, and hardware specifications.
 
-A key metric to monitor for prefill is the Time to First Token (TTFT), which measures the latency from prompt submission to first token generation. More details will be covered in the [inference optimization](/inference-optimization) chapter.
+A key metric to monitor for prefill is the Time to First Token (TTFT), which measures the latency from prompt submission to first token generation. More details will be covered in the [inference optimization](/inference-optimization/) chapter.
 
 <Diagram name="llm-inference-prefill" alt="LLM inference prefill pipeline showing tokenization, prefill, decode, and detokenization stages within Time to First Token (TTFT)" />
 
@@ -77,7 +77,7 @@ Finally, the sequence of generated tokens is decoded back into human-readable te
 
 Compared with prefill, decode is more memory-bound because it requires the model weights and the growing KV cache to be frequently read from memory. KV caching stores these key and value matrices in memory so that, during subsequent token generation, the LLM only needs to compute the keys and values for the new tokens rather than recomputing everything from scratch.
 
-This KV caching mechanism significantly speeds up inference by avoiding redundant computation. However, it comes at the cost of increased memory consumption, since the cache grows with the length of the generated sequence. KV cache memory can become a serving bottleneck even when the model weights already fit on the GPU. Some inference systems reduce this pressure by compressing or quantizing the KV cache, while others move inactive cache blocks to cheaper memory through [KV cache offloading](../inference-optimization/kv-cache-offloading).
+This KV caching mechanism significantly speeds up inference by avoiding redundant computation. However, it comes at the cost of increased memory consumption, since the cache grows with the length of the generated sequence. KV cache memory can become a serving bottleneck even when the model weights already fit on the GPU. Some inference systems reduce this pressure by compressing or quantizing the KV cache, while others move inactive cache blocks to cheaper memory through [KV cache offloading](/inference-optimization/kv-cache-offloading/).
 
 A key metric to monitor for decode is Inter-Token Latency (ITL), the time between the generation of consecutive tokens in a sequence.
 
@@ -89,7 +89,7 @@ Traditional LLM serving systems typically run both the prefill and decode phases
 
 One major issue is the interference between the prefill and decode phases, as they cannot run fully in parallel. In production, multiple requests can arrive at once, each with its own prefill and decode stages that overlap across different requests. However, only one phase can run at a time. When the GPU is occupied with compute-heavy prefill tasks, decode tasks must wait, increasing token latency, and vice versa. This makes it difficult to schedule resources for both phases.
 
-The open-source community is actively working on different strategies to separate prefill and decode. For more information, see [prefill-decode disaggregation](/inference-optimization/prefill-decode-disaggregation).
+The open-source community is actively working on different strategies to separate prefill and decode. For more information, see [prefill-decode disaggregation](/inference-optimization/prefill-decode-disaggregation/).
 
 ## What is a context window and how does it work in LLM inference?
 
@@ -103,7 +103,7 @@ Technically, LLMs don’t have real memory. To keep context, every new request m
 
 This running text history is called the context window, which has a maximum length (e.g., 8K, 32K, or 128K tokens).
 
-As mentioned above, LLMs use the KV cache from previous tokens to avoid fully reprocessing everything in the decode phase, which helps with latency. When reusing the KV cache across multiple requests, it is more accurate to call this technique [prefix caching](../inference-optimization/prefix-caching).
+As mentioned above, LLMs use the KV cache from previous tokens to avoid fully reprocessing everything in the decode phase, which helps with latency. When reusing the KV cache across multiple requests, it is more accurate to call this technique [prefix caching](/inference-optimization/prefix-caching/).
 
 ## Diffusion LLMs (dLLMs)
 
@@ -157,7 +157,7 @@ Before sampling, temperature is applied to the logits (the raw pre-softmax score
 
 After applying temperature and converting logits into probabilities, a sampling strategy determines which token gets picked. Common ones include greedy decoding, top-k, and top-p.
 
-Learn more about [LLM inference parameters](../model-interaction/inference-parameters).
+Learn more about [LLM inference parameters](/model-interaction/inference-parameters/).
 
 ### What happens step by step during LLM inference?
 
@@ -186,7 +186,7 @@ Other factors also affect latency:
 - Input length (longer prompts increase prefill time)
 - Hardware (GPU type and memory bandwidth)
 
-This is why [inference optimization](../inference-optimization) is a major focus in production systems.
+This is why [inference optimization](/inference-optimization/) is a major focus in production systems.
 
 <LinkList>
   ## Additional resources

--- a/docs/llm-inference-basics/llm-inference-metrics.md
+++ b/docs/llm-inference-basics/llm-inference-metrics.md
@@ -123,7 +123,7 @@ There are two common ways to measure throughput:
     Understanding both metrics helps you identify performance bottlenecks based on the nature of your inference workload. For example:
     
     - A summarization request that includes long documents (e.g., 2,000-token inputs) cares more about input TPS.
-    - A chatbot that generates long replies from short [prompts](./../model-interaction/prompt-engineering) (e.g., 20-token prompt → 500-token response) depends heavily on output TPS.
+    - A chatbot that generates long replies from short [prompts](/model-interaction/prompt-engineering/) (e.g., 20-token prompt → 500-token response) depends heavily on output TPS.
     
     When reviewing benchmarks or evaluating LLM performance, **always check whether TPS metrics refer to input, output, or a combined view**. They highlight different strengths and limitations depending on the use case.
     

--- a/docs/llm-inference-basics/training-inference-differences.md
+++ b/docs/llm-inference-basics/training-inference-differences.md
@@ -31,7 +31,7 @@ Training is computationally intensive, often requiring expensive GPU or TPU clus
 
 ## Inference: Using the model in real time
 
-LLM inference means applying the trained model to new data to make predictions. Unlike training, inference [happens continuously and in real-time](./what-is-llm-inference), responding immediately to user input or incoming data. It is the phase where the model is actively "in use." Better-trained and more finely-tuned models typically provide more accurate and useful inference.
+LLM inference means applying the trained model to new data to make predictions. Unlike training, inference [happens continuously and in real-time](/llm-inference-basics/what-is-llm-inference/), responding immediately to user input or incoming data. It is the phase where the model is actively "in use." Better-trained and more finely-tuned models typically provide more accurate and useful inference.
 
 Inference compute needs are ongoing and can become very high, especially as user interactions and traffic grow. Each inference request consumes computational resources such as GPUs. While each inference step may be smaller than training in isolation, the cumulative demand over time can lead to significant operational expenses.
 
@@ -55,7 +55,7 @@ Here is a side-by-side comparison between training and inference:
 
 Model serving is the production process of making a trained model available to applications, users, or systems so it can run inference on new inputs. It usually includes packaging the model, loading it onto suitable hardware, exposing it through an API or service, monitoring its behavior, and keeping latency, reliability, security, and cost under control.
 
-Learn more about the difference between [serving and inference](./what-is-llm-inference#whats-the-difference-between-serving-and-inference).
+Learn more about the difference between [serving and inference](/llm-inference-basics/what-is-llm-inference/#whats-the-difference-between-serving-and-inference).
 
 ### Where do training and inference fit in the LLM lifecycle?
 
@@ -63,12 +63,12 @@ Training happens early in the lifecycle. The model learns patterns, language str
 
 ### Why does LLM inference often cost more than training?
 
-Even though training an LLM is expensive, it usually happens once. Inference, on the other hand, runs every time a user sends a request. As traffic grows, the number of inference calls grows with it. Each request uses GPU compute, memory, and network bandwidth. Over time, this ongoing demand can make inference the larger long-term expense, especially for applications with heavy usage or long [prompts](./../model-interaction/prompt-engineering).
+Even though training an LLM is expensive, it usually happens once. Inference, on the other hand, runs every time a user sends a request. As traffic grows, the number of inference calls grows with it. Each request uses GPU compute, memory, and network bandwidth. Over time, this ongoing demand can make inference the larger long-term expense, especially for applications with heavy usage or long [prompts](/model-interaction/prompt-engineering/).
 
 ### Should I train my own LLM?
 
-In most cases, no. Training a new LLM from scratch requires massive datasets, specialized hardware, and a dedicated research team. Most companies get better results by starting with an existing [open-source LLM](../getting-started/choosing-the-right-model) and then fine-tuning or customizing it for their domain. Full training only makes sense if you’re solving a problem that existing models can’t handle or you have strict control requirements that fine-tuning can’t meet.
+In most cases, no. Training a new LLM from scratch requires massive datasets, specialized hardware, and a dedicated research team. Most companies get better results by starting with an existing [open-source LLM](/getting-started/choosing-the-right-model/) and then fine-tuning or customizing it for their domain. Full training only makes sense if you’re solving a problem that existing models can’t handle or you have strict control requirements that fine-tuning can’t meet.
 
 ### Is fine-tuning considered training or inference?
 
-Fine-tuning is a form of training. You update some of the model’s weights using new data to adapt it to a specific task or domain. Inference doesn’t change any weights. It only uses the model to generate predictions. See the [fine-tuning section](../model-preparation/llm-fine-tuning) to learn more.
+Fine-tuning is a form of training. You update some of the model’s weights using new data to adapt it to a specific task or domain. Inference doesn’t change any weights. It only uses the model to generate predictions. See the [fine-tuning section](/model-preparation/llm-fine-tuning/) to learn more.

--- a/docs/llm-inference-basics/what-is-llm-inference.md
+++ b/docs/llm-inference-basics/what-is-llm-inference.md
@@ -11,7 +11,7 @@ import RequestLifecycle from '@site/src/components/RequestLifecycle';
 
 # What is LLM inference?
 
-LLM inference refers to using trained LLMs, such as GPT-5, GLM-5, and DeepSeek-V3.2, to generate meaningful outputs from user inputs, typically provided as natural language [prompts](./../model-interaction/prompt-engineering). During inference, the model processes the prompt through its vast set of parameters to generate responses like text, code snippets, summaries, and translations.
+LLM inference refers to using trained LLMs, such as GPT-5, GLM-5, and DeepSeek-V3.2, to generate meaningful outputs from user inputs, typically provided as natural language [prompts](/model-interaction/prompt-engineering/). During inference, the model processes the prompt through its vast set of parameters to generate responses like text, code snippets, summaries, and translations.
 
 Essentially, this is the moment the LLM is actively "in action." Here are some real-world examples:
 
@@ -20,7 +20,7 @@ Essentially, this is the moment the LLM is actively "in action." Here are some r
 - **Developer tools**: Converting natural language descriptions into executable code.
 - **AI agents**: Performing complex, multi-step reasoning and decision-making processes autonomously.
 
-Use the visualizer below to see how a request flows during LLM inference. For details, learn [how LLM inference works](./how-does-llm-inference-work).
+Use the visualizer below to see how a request flows during LLM inference. For details, learn [how LLM inference works](/llm-inference-basics/how-does-llm-inference-work/).
 
 <RequestLifecycle />
 
@@ -40,7 +40,7 @@ In the LLM space, people often use **inference server** or **inference framework
 - **An inference server** usually emphasizes the runtime component that receives requests, runs models, and returns results.
 - **An inference framework** often highlights the broader toolkit or library that provides APIs, optimizations, and integrations for serving models efficiently.
 
-Popular [inference frameworks](../getting-started/choosing-the-right-inference-framework) include vLLM, SGLang, MAX, and TensorRT-LLM. They’re designed to maximize GPU efficiency while making LLMs easier to deploy at scale.
+Popular [inference frameworks](/getting-started/choosing-the-right-inference-framework/) include vLLM, SGLang, MAX, and TensorRT-LLM. They’re designed to maximize GPU efficiency while making LLMs easier to deploy at scale.
 
 ## What's the difference between serving and inference?
 
@@ -61,16 +61,16 @@ So when someone uses them interchangeably, they're usually being loose about the
 
 Some common strategies include:
 
-- [Continuous batching](../inference-optimization/static-dynamic-continuous-batching): Dynamically grouping requests for better GPU utilization
-- [KV cache management](../inference-optimization/kv-cache-offloading): Reusing or offloading attention caches to handle long prompts efficiently
-- [Speculative decoding](../inference-optimization/speculative-decoding): Using a smaller draft model to speed up token generation
-- [Quantization](../model-preparation/llm-quantization): Running models in lower precision (e.g., INT8, FP8) to save memory and compute
-- [Prefix caching](../inference-optimization/prefix-caching): Caching common prompt segments to reduce redundant computation
-- [Multi-GPU distribution/Parallelism](../inference-optimization/data-tensor-pipeline-expert-hybrid-parallelism): Splitting LLMs across multiple GPUs for larger context windows
+- [Continuous batching](/inference-optimization/static-dynamic-continuous-batching/): Dynamically grouping requests for better GPU utilization
+- [KV cache management](/inference-optimization/kv-cache-offloading/): Reusing or offloading attention caches to handle long prompts efficiently
+- [Speculative decoding](/inference-optimization/speculative-decoding/): Using a smaller draft model to speed up token generation
+- [Quantization](/model-preparation/llm-quantization/): Running models in lower precision (e.g., INT8, FP8) to save memory and compute
+- [Prefix caching](/inference-optimization/prefix-caching/): Caching common prompt segments to reduce redundant computation
+- [Multi-GPU distribution/Parallelism](/inference-optimization/data-tensor-pipeline-expert-hybrid-parallelism/): Splitting LLMs across multiple GPUs for larger context windows
 
 In practice, inference optimization can make the difference between an application that feels sluggish and expensive, and one that delivers snappy, cost-efficient user experiences.
 
-Learn more in the [inference optimization](../inference-optimization/) chapter.
+Learn more in the [inference optimization](/inference-optimization/) chapter.
 
 ## Why should I care about LLM inference?
 
@@ -82,10 +82,10 @@ But here’s the thing: **the further you go, the more inference matters.**
 
 As your application grows, you'll eventually run into limits (e.g., cost, latency, customization, or compliance) that serverless APIs can’t fully address. That’s when teams start exploring hybrid or self-hosted solutions.
 
-Understanding LLM inference (e.g., [batching](../inference-optimization/static-dynamic-continuous-batching), [caching](../inference-optimization/prefix-caching), [quantization](../model-preparation/llm-quantization) and [routing](../inference-optimization/inference-routing)) early gives you a clear edge. It helps you evaluate the features of different model service providers and [inference frameworks](../getting-started/choosing-the-right-inference-framework), so you can make smarter choices, avoid surprises, and build more scalable systems.
+Understanding LLM inference (e.g., [batching](/inference-optimization/static-dynamic-continuous-batching/), [caching](/inference-optimization/prefix-caching/), [quantization](/model-preparation/llm-quantization/) and [routing](/inference-optimization/inference-routing/)) early gives you a clear edge. It helps you evaluate the features of different model service providers and [inference frameworks](/getting-started/choosing-the-right-inference-framework/), so you can make smarter choices, avoid surprises, and build more scalable systems.
 
 - **If you're a developer or engineer**: Inference is becoming as fundamental as databases or APIs in modern AI application development. Knowing how it works helps you design faster, cheaper, and more reliable systems. Poor inference implementation can lead to slow response time, high compute costs, and a poor user experience.
 - **If you're a technical leader**: Inference efficiency directly affects your bottom line. A poorly optimized setup can cost 10× more in GPU hours while delivering worse performance. Understanding inference helps you evaluate vendors, make build-vs-buy decisions, and set realistic performance goals for your team.
 - **If you're just curious about AI**: Inference is where the magic happens. Knowing how it works helps you separate AI hype from reality and makes you a more informed consumer and contributor to AI discussions.
 
-For more information, see [serverless vs. self-hosted LLM inference](../getting-started/serverless-vs-self-hosted-llm-inference).
+For more information, see [serverless vs. self-hosted LLM inference](/getting-started/serverless-vs-self-hosted-llm-inference/).

--- a/docs/model-interaction/anthropic-compatible-api.md
+++ b/docs/model-interaction/anthropic-compatible-api.md
@@ -119,7 +119,7 @@ A compatible endpoint speaks the Anthropic schema, but it isn’t the official A
 - **Configuration is often done via environment variables**. Many frameworks’ docs recommend setting the API key and base URL through environment variables (so the Anthropic SDK picks them up automatically) rather than hard-coding them in client code. The idea is the same across frameworks, but the specific variable names can differ.
 - **Not all API fields are supported**. Common fields like `model`, `messages`, and `max_tokens` are usually fine, but coverage thins out beyond that. For example:
   - **Modalities**. The official Anthropic API accepts types like `"image"` and `"document"`. For many open-source LLMs, these are simply not supported. Always check the compatibility doc before assuming a content type will go through.
-  - **Advanced features**. Capabilities like [prompt caching](../inference-optimization/prefix-caching) (`cache_control` for caching prefixes), extended thinking, and some [tool-use](./function-calling) options may be ignored or rejected. If you depend on these, verify they work end-to-end before porting an Anthropic-based application.
+  - **Advanced features**. Capabilities like [prompt caching](/inference-optimization/prefix-caching/) (`cache_control` for caching prefixes), extended thinking, and some [tool-use](/model-interaction/function-calling/) options may be ignored or rejected. If you depend on these, verify they work end-to-end before porting an Anthropic-based application.
 
 ## When to use it
 
@@ -128,7 +128,7 @@ Choose an Anthropic-compatible endpoint when:
 - Your application or agent stack is already built on the Anthropic API (e.g., Claude Code, Claude Agent SDK, or custom agent loops using Anthropic-style tool use).
 - The downstream tooling (SDKs, proxies, evaluators) expects the Anthropic schema, and rewriting it to OpenAI-compatible is more work than running a compatible endpoint.
 
-For new applications without an existing integration, the [OpenAI-compatible API](./openai-compatible-api) remains the more broadly supported default. If your main concern is predictable machine-readable responses, also compare the API surface with [structured outputs](./structured-outputs) support in your chosen backend.
+For new applications without an existing integration, the [OpenAI-compatible API](/model-interaction/openai-compatible-api/) remains the more broadly supported default. If your main concern is predictable machine-readable responses, also compare the API surface with [structured outputs](/model-interaction/structured-outputs/) support in your chosen backend.
 
 ## FAQs
 

--- a/docs/model-interaction/function-calling.md
+++ b/docs/model-interaction/function-calling.md
@@ -32,7 +32,7 @@ At a technical level, the LLM still predicts the next token, just like any other
 
 These two ideas get mixed up a lot. Here’s the simple difference:
 
-- Structured outputs: You decide the [format that the model uses in its responses](./structured-outputs). For example, you can force the model to output JSON, a list, or a specific object.
+- Structured outputs: You decide the [format that the model uses in its responses](/model-interaction/structured-outputs/). For example, you can force the model to output JSON, a list, or a specific object.
 - Function calling: You tell the model when to take an action. Function calling tools are often defined in a structured way (e.g., JSON).
 
 Both can be used together.

--- a/docs/model-interaction/inference-parameters.md
+++ b/docs/model-interaction/inference-parameters.md
@@ -14,18 +14,18 @@ import TopPvsTopK from '@site/src/components/TopPvsTopK';
 
 # LLM inference parameters
 
-Inference parameters are the settings you pass with an LLM request to control how the model generates responses. They do not change the model weights. Instead, they impact the [decoding process](../llm-inference-basics/how-does-llm-inference-work), such as: 
+Inference parameters are the settings you pass with an LLM request to control how the model generates responses. They do not change the model weights. Instead, they impact the [decoding process](/llm-inference-basics/how-does-llm-inference-work/), such as: 
 
 - How the next token is selected
 - How long the model can keep generating
 - When it should stop
 - How much repetition is allowed.
 
-Some parameters mainly affect output quality and style, while others have direct serving implications for scheduling, [throughput](../llm-inference-basics/llm-inference-metrics), memory usage, and production cost.
+Some parameters mainly affect output quality and style, while others have direct serving implications for scheduling, [throughput](/llm-inference-basics/llm-inference-metrics/), memory usage, and production cost.
 
 ## Common inference parameters
 
-You will see these parameters in hosted APIs, [OpenAI-compatible servers](./openai-compatible-api), [inference frameworks](../getting-started/choosing-the-right-inference-framework) like vLLM and SGLang, and agentic frameworks. Here is a quick summary of the common ones:
+You will see these parameters in hosted APIs, [OpenAI-compatible servers](/model-interaction/openai-compatible-api/), [inference frameworks](/getting-started/choosing-the-right-inference-framework/) like vLLM and SGLang, and agentic frameworks. Here is a quick summary of the common ones:
 
 | Parameter | What it controls | Common use |
 | --- | --- | --- |
@@ -54,12 +54,12 @@ Higher temperature flattens the distribution. Less likely tokens get more chance
 
 Common patterns:
 
-- Use low temperature for factual question answering, extraction, classification, and [structured workflows](./structured-outputs).
+- Use low temperature for factual question answering, extraction, classification, and [structured workflows](/model-interaction/structured-outputs/).
 - Use moderate temperature for chat, summarization, and product copy if you can accept some variation.
 - Use higher temperature for brainstorming, fiction, naming, and other creative tasks.
 - Use `temperature: 0` or near-zero values when you want greedy or near-deterministic decoding.
 
-Low temperature does not guarantee factual accuracy. It only reduces randomness in the decode step. A model can still give a confident wrong answer if the [prompt](./prompt-engineering) lacks grounding, the model lacks knowledge, or the application does not verify outputs.
+Low temperature does not guarantee factual accuracy. It only reduces randomness in the decode step. A model can still give a confident wrong answer if the [prompt](/model-interaction/prompt-engineering/) lacks grounding, the model lacks knowledge, or the application does not verify outputs.
 
 ## Top-p and top-k sampling
 
@@ -88,7 +88,7 @@ Many systems let you use `temperature`, `top_p`, and `top_k` together. This 
 A practical starting point:
 
 - Tune `temperature` first.
-- Use [greedy decoding](../llm-inference-basics/how-does-llm-inference-work#how-are-tokens-selected-via-sampling) if you want the model to select the highest probability token at each step. It is deterministic in a fixed serving setup, but can be prone to repetition.
+- Use [greedy decoding](/llm-inference-basics/how-does-llm-inference-work/#how-are-tokens-selected-via-sampling) if you want the model to select the highest probability token at each step. It is deterministic in a fixed serving setup, but can be prone to repetition.
 - Use `top_p` when you want to bound the long tail and keep sampling adaptive.
 - Use `top_k` when your inference framework or model family recommends it, or when you need a hard cap on candidate tokens.
 - Combine `top_k` and `top_p`: In many samplers, top-k removes the low-ranked tail first, then top-p refines the candidate set further.
@@ -96,7 +96,7 @@ A practical starting point:
 
 ## Output length
 
-Length parameters directly affect [latency](../llm-inference-basics/llm-inference-metrics) and cost because LLMs generate one token at a time during decode.
+Length parameters directly affect [latency](/llm-inference-basics/llm-inference-metrics/) and cost because LLMs generate one token at a time during decode.
 
 `max_tokens` sets the maximum number of tokens the model can produce. This is one of the most important production controls. If it is too low, responses get cut off. If it is too high, bad prompts or edge cases can waste GPU time and increase tail latency.
 
@@ -109,7 +109,7 @@ Good defaults depend on the application:
 - **Code generation or long-form writing**: Larger limits, with stronger monitoring for latency and cost.
 - **Batch jobs**: Explicit length limits so one bad input does not dominate the run.
 
-For inference systems, output length also affects scheduling. Long generations hold active request state longer, consume [KV cache](../llm-inference-basics/how-does-llm-inference-work#prefill) longer, and can interfere with latency-sensitive traffic.
+For inference systems, output length also affects scheduling. Long generations hold active request state longer, consume [KV cache](/llm-inference-basics/how-does-llm-inference-work/#prefill) longer, and can interfere with latency-sensitive traffic.
 
 ## Stop sequences
 
@@ -119,9 +119,9 @@ They are useful when the output has a clear boundary:
 
 - Stop at `"\n\nUser:"` in a chat transcript format.
 - Stop at `"</json>"` or another delimiter in a structured prompt.
-- Stop after one list item, one SQL statement, or one [tool call](./function-calling).
+- Stop after one list item, one SQL statement, or one [tool call](/model-interaction/function-calling/).
 
-Stop sequences are not a replacement for schema enforcement. They only end generation when a sequence appears. If you need guaranteed JSON, use [structured outputs](./structured-outputs) or constrained decoding when your provider supports it.
+Stop sequences are not a replacement for schema enforcement. They only end generation when a sequence appears. If you need guaranteed JSON, use [structured outputs](/model-interaction/structured-outputs/) or constrained decoding when your provider supports it.
 
 Be careful with common substrings. A stop sequence that appears inside normal content can cut off valid answers.
 
@@ -175,7 +175,7 @@ More advanced inference parameters can restrict or alter token selection directl
 - `bad_words` blocks certain word sequences.
 - `allowed_token_ids` restricts generation to a specific token set. These are powerful but easy to misuse because tokenization does not always match human-visible words.
 
-Use advanced controls when the output is consumed by software. For example, extraction pipelines, [function calling](./function-calling), and [structured data generation](./structured-outputs) usually need stronger guarantees than prompt instructions alone can provide.
+Use advanced controls when the output is consumed by software. For example, extraction pipelines, [function calling](/model-interaction/function-calling/), and [structured data generation](/model-interaction/structured-outputs/) usually need stronger guarantees than prompt instructions alone can provide.
 
 ## Recommended starting points
 
@@ -196,7 +196,7 @@ Still, the following ranges are useful starting points for evaluation:
 
 These are starting points, not rules. Always evaluate parameters with your actual prompts, model versions, and workloads.
 
-For production systems, parameter tuning is also an infrastructure concern. For example, higher output lengths and more exploratory sampling can increase [latency](../llm-inference-basics/llm-inference-metrics), GPU utilization, KV cache pressure, and tail latency under load.
+For production systems, parameter tuning is also an infrastructure concern. For example, higher output lengths and more exploratory sampling can increase [latency](/llm-inference-basics/llm-inference-metrics/), GPU utilization, KV cache pressure, and tail latency under load.
 
 ## FAQs
 

--- a/docs/model-interaction/openai-compatible-api.md
+++ b/docs/model-interaction/openai-compatible-api.md
@@ -40,7 +40,7 @@ OpenAI-compatible APIs address these challenges by providing:
 - **Seamless migration**: Move between providers or self-hosted deployments with minimal disruption.
 - **Consistent integration**: Maintain compatibility with tools and frameworks that rely on the OpenAI API schema (e.g., `chat/completions`, `embeddings` endpoints).
 
-Many [inference backends](../getting-started/choosing-the-right-inference-framework) (e.g., vLLM and SGLang) and model serving frameworks (e.g., MAX) provide OpenAI-compatible endpoints out of the box. This makes it easier to switch between different models without changing client code.
+Many [inference backends](/getting-started/choosing-the-right-inference-framework/) (e.g., vLLM and SGLang) and model serving frameworks (e.g., MAX) provide OpenAI-compatible endpoints out of the box. This makes it easier to switch between different models without changing client code.
 
 ## How to call an OpenAI-compatible API
 
@@ -140,7 +140,7 @@ curl https://your-custom-endpoint.com/v1/models \
 
 Use any returned `id` as the `model` field in your chat completion requests. Note that not every framework exposes this endpoint.
 
-Most compatible endpoints also accept common [LLM inference parameters](./inference-parameters), such as `temperature`, `top_p`, and `max_tokens`. Support varies across providers and self-hosted backends, so verify the exact fields your server accepts before using them in production.
+Most compatible endpoints also accept common [LLM inference parameters](/model-interaction/inference-parameters/), such as `temperature`, `top_p`, and `max_tokens`. Support varies across providers and self-hosted backends, so verify the exact fields your server accepts before using them in production.
 
 ## FAQs
 
@@ -170,11 +170,11 @@ Not by itself. The API format is just an interface. It doesn’t make inference 
 
 Cost savings come from where the API is running. Here’s the breakdown:
 
-- **If you self-host LLMs through tools like vLLM and SGLang**, you mainly pay for GPUs instead of per-token pricing. You can apply inference optimizations like [KV cache offloading](../inference-optimization/kv-cache-offloading) and [prefill-decode disaggregation](../inference-optimization/prefill-decode-disaggregation) to improve utilization and potentially reduce serving cost. This can be far cheaper for steady or high-volume workloads when the deployment is well utilized.
+- **If you self-host LLMs through tools like vLLM and SGLang**, you mainly pay for GPUs instead of per-token pricing. You can apply inference optimizations like [KV cache offloading](/inference-optimization/kv-cache-offloading/) and [prefill-decode disaggregation](/inference-optimization/prefill-decode-disaggregation/) to improve utilization and potentially reduce serving cost. This can be far cheaper for steady or high-volume workloads when the deployment is well utilized.
 - **If you use a hosted provider (e.g., Together AI, Fireworks)**, you still pay per-token or per-request, even if the API is “OpenAI-compatible.”
 - **If you stay on OpenAI**, you pay per-token at OpenAI pricing.
 
-The reason some AI teams save money isn’t the OpenAI-compatible API; it’s the ability to self-host any model without breaking their existing application code. Learn more about [serverless vs. self-hosted LLM inference](../getting-started/serverless-vs-self-hosted-llm-inference).
+The reason some AI teams save money isn’t the OpenAI-compatible API; it’s the ability to self-host any model without breaking their existing application code. Learn more about [serverless vs. self-hosted LLM inference](/getting-started/serverless-vs-self-hosted-llm-inference/).
 
 <LinkList>
   ## Additional resources

--- a/docs/model-interaction/prompt-engineering.md
+++ b/docs/model-interaction/prompt-engineering.md
@@ -55,7 +55,7 @@ For high-throughput inference systems, prompt length becomes an important optimi
 
 ### KV cache usage
 
-LLM inference relies heavily on the [KV cache (Key-Value cache)](../llm-inference-basics/how-does-llm-inference-work/#prefill) to speed up generation.
+LLM inference relies heavily on the [KV cache (Key-Value cache)](/llm-inference-basics/how-does-llm-inference-work/#prefill) to speed up generation.
 
 During the prefill stage, the model processes the entire prompt and stores intermediate attention states in the KV cache. During decoding, the model reuses this cache instead of recomputing attention for previous tokens.
 
@@ -92,7 +92,7 @@ In many AI deployments, prompt engineering becomes the first layer of control ov
 
 Because prompts are part of the request payload, they can be updated quickly without retraining models or changing the serving infrastructure. This makes prompts a flexible way to steer model behavior in production.
 
-Prompt engineering is often tuned together with [inference parameters](./inference-parameters). The prompt defines the task and constraints, while parameters such as `temperature`, `top_p`, and `max_tokens` control how the model samples and bounds the response.
+Prompt engineering is often tuned together with [inference parameters](/model-interaction/inference-parameters/). The prompt defines the task and constraints, while parameters such as `temperature`, `top_p`, and `max_tokens` control how the model samples and bounds the response.
 
 ## Prompt roles
 
@@ -209,8 +209,8 @@ For large inference systems, long conversations can reduce throughput and increa
 
 - Message truncation to keep only the most recent turns
 - Conversation summarization to compress older context
-- [Prefix caching](./../inference-optimization/prefix-caching) to reuse shared prompt segments
-- [KV cache offloading](./../inference-optimization/kv-cache-offloading) to move cache data to low-cost storage when needed
+- [Prefix caching](/inference-optimization/prefix-caching/) to reuse shared prompt segments
+- [KV cache offloading](/inference-optimization/kv-cache-offloading/) to move cache data to low-cost storage when needed
 
 #### Injected by developers
 
@@ -276,7 +276,7 @@ Small wording changes sometimes produce large differences. Prompt engineering of
 
 ---
 
-As you build real systems, you’ll likely combine LLM prompt engineering with other techniques such as [structured outputs](./structured-outputs), [tool calling](./function-calling), and [fine-tuning](../model-preparation/llm-fine-tuning). Understanding how prompts impact model behavior is the first step toward building robust LLM applications.
+As you build real systems, you’ll likely combine LLM prompt engineering with other techniques such as [structured outputs](/model-interaction/structured-outputs/), [tool calling](/model-interaction/function-calling/), and [fine-tuning](/model-preparation/llm-fine-tuning/). Understanding how prompts impact model behavior is the first step toward building robust LLM applications.
 
 ## FAQs
 
@@ -376,7 +376,7 @@ Therefore, some production systems generate reasoning internally and only return
 
 ### When does prompt engineering fail?
 
-Prompt engineering is powerful, but it has limits. If a task requires domain knowledge that the model does not possess, or you need strict consistency across millions of requests, prompt engineering alone may not be sufficient. In these cases, techniques such as [fine-tuning](../model-preparation/llm-fine-tuning), RAG, or [constrained decoding](./structured-outputs#constrained-decoding) may be necessary.
+Prompt engineering is powerful, but it has limits. If a task requires domain knowledge that the model does not possess, or you need strict consistency across millions of requests, prompt engineering alone may not be sufficient. In these cases, techniques such as [fine-tuning](/model-preparation/llm-fine-tuning/), RAG, or [constrained decoding](/model-interaction/structured-outputs/#constrained-decoding) may be necessary.
 
 <LinkList>
   ## Additional resources

--- a/docs/model-interaction/structured-outputs.md
+++ b/docs/model-interaction/structured-outputs.md
@@ -124,7 +124,7 @@ Re-prompting is a simple and effective way to get structured outputs using libra
 
 Here’s how it works:
 
-1. You send the model a [prompt](./prompt-engineering) describing the desired format (for example, a JSON schema).
+1. You send the model a [prompt](/model-interaction/prompt-engineering/) describing the desired format (for example, a JSON schema).
 2. The library checks whether the response is valid.
 3. If not, it automatically re-prompts the model with details about what went wrong.
 4. The process repeats until the output passes validation or a retry limit is reached.

--- a/docs/model-preparation/llm-distillation.md
+++ b/docs/model-preparation/llm-distillation.md
@@ -19,7 +19,7 @@ A simple way to think about it:
 - The teacher already knows how to solve the task well
 - The student learns by copying the outputs from the teacher
 
-Unlike [quantization](./llm-quantization), which reduces the precision of existing weights, distillation produces an entirely new model. The two techniques are complementary. A distilled model can also be quantized for further efficiency.
+Unlike [quantization](/model-preparation/llm-quantization/), which reduces the precision of existing weights, distillation produces an entirely new model. The two techniques are complementary. A distilled model can also be quantized for further efficiency.
 
 DeepSeek-R1 (671B parameters) is a good example of what distillation enables. Researchers used it to transfer reasoning ability into smaller models, including 1.5B, 7B, 8B, 14B, 32B, and 70B variants. They reason in a style similar to the teacher, at a fraction of the inference cost.
 
@@ -89,7 +89,7 @@ You can think of it this way:
 
 - Distillation makes the model smaller
 - Quantization makes the model lighter
-- [Inference optimizations](../inference-optimization) (like [prefix caching](../inference-optimization/prefix-caching)) make serving more efficient
+- [Inference optimizations](/inference-optimization/) (like [prefix caching](/inference-optimization/prefix-caching/)) make serving more efficient
 
 You can combine these techniques in you inference systems: Large model → Distill → Smaller model → Quantize (if needed) → Optimize serving → Deploy
 

--- a/docs/model-preparation/llm-fine-tuning.md
+++ b/docs/model-preparation/llm-fine-tuning.md
@@ -17,11 +17,11 @@ For example, fine-tuning can significantly improve a model’s:
 
 - **Domain expertise**: Adapting a model for legal, medical, or programming-related tasks.
 - **Instruction following**: Ensuring the model adheres to specific formats, tones, or styles in its responses.
-- **Safety and alignment**: Reinforcing how the model handles sensitive or high-risk [prompts](../model-interaction/prompt-engineering).
+- **Safety and alignment**: Reinforcing how the model handles sensitive or high-risk [prompts](/model-interaction/prompt-engineering/).
 
 ## Where fine-tuning fits in the customization stack
 
-Fine-tuning is only one approach to customization. It changes model weights, which makes it different from other techniques such as [prompt engineering](../model-interaction/prompt-engineering), [function calling](../model-interaction/function-calling), and [structured outputs](../model-interaction/structured-outputs).
+Fine-tuning is only one approach to customization. It changes model weights, which makes it different from other techniques such as [prompt engineering](/model-interaction/prompt-engineering/), [function calling](/model-interaction/function-calling/), and [structured outputs](/model-interaction/structured-outputs/).
 
 The difference matters in production. Runtime techniques are usually faster to test, easier to roll back, and more portable across model providers. Fine-tuning is more appropriate when the behavior you want is stable, appears across many requests, and cannot be handled cleanly by prompts or retrieved context alone.
 
@@ -50,7 +50,7 @@ Key features:
 
 - Supports popular open-weight models like Llama, Pythia, Falcon, and MPT.
 - Flexible training options: full fine-tuning, LoRA, QLoRA, ReLoRA, and GPTQ.
-- Compatible with advanced techniques like xFormers, [FlashAttention](../kernel-optimization/flashattention), ROPE scaling, Liger kernel, and sample packing.
+- Compatible with advanced techniques like xFormers, [FlashAttention](/kernel-optimization/flashattention/), ROPE scaling, Liger kernel, and sample packing.
 - Scales from single GPU setups to multi-GPU training using FSDP or DeepSpeed.
 - Easy to run locally with Docker or on cloud infrastructure.
 
@@ -60,7 +60,7 @@ Axolotl is great for users who want to focus on their data and tasks instead of 
 
 [Unsloth](https://unsloth.ai/) is a fine-tuning framework designed to make training LLMs faster, lighter, and more accessible, especially on limited hardware (e.g., free Google Colab GPUs).
 
-Unsloth is deeply optimized at the kernel level. Built with a custom attention implementation in [Triton](https://openai.com/index/triton), it enables 2× faster training with up to 80% less memory usage. If you want more background on where Triton fits relative to CUDA and compiler-based approaches, see [kernel optimization tools](../kernel-optimization/kernel-optimization-tools).
+Unsloth is deeply optimized at the kernel level. Built with a custom attention implementation in [Triton](https://openai.com/index/triton), it enables 2× faster training with up to 80% less memory usage. If you want more background on where Triton fits relative to CUDA and compiler-based approaches, see [kernel optimization tools](/kernel-optimization/kernel-optimization-tools/).
 
 The Unsloth team has collaborated directly with developers behind models like Llama 4, Mistral, Qwen, Gemma, and Phi, often contributing bug fixes and updates that improve prompt handling, accuracy, and overall stability.
 
@@ -110,7 +110,7 @@ Key features:
 
 ---
 
-Instead of fine-tuning a model yourself, you can often start with an existing fine-tuned or instruction-tuned model from [Hugging Face](../getting-started/choosing-the-right-model/#hugging-face). It hosts a large collection of community and officially released fine-tuned models that are ready to use out of the box. At the same time, it also provides base models and foundation checkpoints if you want full control and plan to fine-tune the model yourself. In practice, teams frequently explore both options on Hugging Face before deciding whether to reuse an existing model or invest in custom fine-tuning.
+Instead of fine-tuning a model yourself, you can often start with an existing fine-tuned or instruction-tuned model from [Hugging Face](/getting-started/choosing-the-right-model/#hugging-face). It hosts a large collection of community and officially released fine-tuned models that are ready to use out of the box. At the same time, it also provides base models and foundation checkpoints if you want full control and plan to fine-tune the model yourself. In practice, teams frequently explore both options on Hugging Face before deciding whether to reuse an existing model or invest in custom fine-tuning.
 
 ## Fine-tuning through a hosted provider
 
@@ -141,7 +141,7 @@ Here’s a clearer side-by-side comparison:
 
 ### How does LLM fine-tuning compare to other techniques like prompt engineering?
 
-[Prompt engineering](../model-interaction/prompt-engineering) adjusts how you ask the model to get better answers. It’s quick, cheap, and doesn’t require training, but it has limits. Long prompts can get messy, and the model may still behave inconsistently.
+[Prompt engineering](/model-interaction/prompt-engineering/) adjusts how you ask the model to get better answers. It’s quick, cheap, and doesn’t require training, but it has limits. Long prompts can get messy, and the model may still behave inconsistently.
 
 Fine-tuning actually changes the model. You feed it examples of what “good” looks like, and it learns to follow that pattern on its own. It’s more reliable for long-term use, especially when you need consistent tone, domain knowledge, or strict formatting.
 
@@ -149,7 +149,7 @@ In short, prompt engineering is great for early exploration, but fine-tuning giv
 
 ### When should I avoid fine-tuning?
 
-Avoid fine-tuning when the main problem is missing or frequently changing information. A [RAG pipeline](../infrastructure-and-operations/multi-model-inference-pipelines/#rag-pipeline), prompt template, or tool call is usually a better fit because it can fetch fresh data at inference time.
+Avoid fine-tuning when the main problem is missing or frequently changing information. A [RAG pipeline](/infrastructure-and-operations/multi-model-inference-pipelines/#rag-pipeline), prompt template, or tool call is usually a better fit because it can fetch fresh data at inference time.
 
 Fine-tuning is also a poor first step when you do not have a reliable evaluation set. Without it, it is hard to tell whether a fine-tuned model actually improved the target behavior or simply changed its style.
 

--- a/docs/model-preparation/llm-quantization.md
+++ b/docs/model-preparation/llm-quantization.md
@@ -28,10 +28,10 @@ These figures only account for model weights. Runtime elements, such as attentio
 Quantization can help LLM inference in three main ways:
 
 - **Smaller model footprint**. The number of bits per parameter directly affects how much memory the model weights require. For example, a 7B model needs about 14 GB for FP16 weights but about 7 GB for INT8 weights. This can make the difference between fitting the model on one GPU or distributing it across multiple GPUs or nodes.
-- **Less data movement**. LLM decoding is often limited by GPU memory bandwidth because the runtime repeatedly reads model weights while generating tokens. Lower-precision weights mean fewer bytes to be moved from [GPU memory to the compute units](../kernel-optimization/gpu-architecture-fundamentals), which can reduce per-token latency.
+- **Less data movement**. LLM decoding is often limited by GPU memory bandwidth because the runtime repeatedly reads model weights while generating tokens. Lower-precision weights mean fewer bytes to be moved from [GPU memory to the compute units](/kernel-optimization/gpu-architecture-fundamentals/), which can reduce per-token latency.
 - **Faster computation**. GPUs and other accelerators can process supported low-precision formats at higher throughput than FP32 or FP16. [On the H100 SXM](https://www.nvidia.com/en-us/data-center/h100/), for example, the BF16/FP16 tensor cores hit 1,979 TFLOPS, while FP8 and INT8 double that to 3,958 TFLOPS/TOPS, a clean 2x from halving the bit width. The actual speedup depends on whether the hardware and inference runtime provide optimized kernels for the chosen format.
 
-A smaller weight footprint also leaves more GPU memory available for the [KV cache](../llm-inference-basics/how-does-llm-inference-work#the-two-phases-of-llm-inference), larger batches, and more concurrent requests. Weight quantization does not reduce the KV cache size per token by itself. It requires quantizing the KV cache separately.
+A smaller weight footprint also leaves more GPU memory available for the [KV cache](/llm-inference-basics/how-does-llm-inference-work/#the-two-phases-of-llm-inference), larger batches, and more concurrent requests. Weight quantization does not reduce the KV cache size per token by itself. It requires quantizing the KV cache separately.
 
 This tradeoff between precision and size comes with **some drop in accuracy**. For many applications, the above benefits matter only if the generated output remains reliable enough for production use. For example, a faster model that produces noticeably worse responses is rarely a worthwhile trade-off.
 
@@ -54,7 +54,7 @@ Use the visualizer below to see how these tradeoffs play out for your model size
 
 <QuantizationVisualizer />
 
-This calculator estimates **weight memory only**. Use the [GPU memory calculator](../getting-started/calculating-gpu-memory-for-llms) to estimate your overall requirements.
+This calculator estimates **weight memory only**. Use the [GPU memory calculator](/getting-started/calculating-gpu-memory-for-llms/) to estimate your overall requirements.
 
 ## What to quantize
 
@@ -150,9 +150,9 @@ GPTQ is widely used in open-source model serving pipelines, especially with Auto
 
 ---
 
-Many [modern inference frameworks](../getting-started/choosing-the-right-inference-framework) not only serve quantized models efficiently but also provide built-in APIs or tooling to quantize models. In other cases, models are quantized offline using specialized tools and then loaded directly by the serving framework. As a result, most users no longer need to implement quantization algorithms themselves.
+Many [modern inference frameworks](/getting-started/choosing-the-right-inference-framework/) not only serve quantized models efficiently but also provide built-in APIs or tooling to quantize models. In other cases, models are quantized offline using specialized tools and then loaded directly by the serving framework. As a result, most users no longer need to implement quantization algorithms themselves.
 
-You can often start with an already quantized model from [Hugging Face](../getting-started/choosing-the-right-model/#hugging-face). It hosts many pre-quantized variants, such as 8-bit and 4-bit models, that are ready for inference and optimized for lower memory usage and faster deployment. At the same time, it also provides full-precision base models if you want to apply your own quantization strategy.
+You can often start with an already quantized model from [Hugging Face](/getting-started/choosing-the-right-model/#hugging-face). It hosts many pre-quantized variants, such as 8-bit and 4-bit models, that are ready for inference and optimized for lower memory usage and faster deployment. At the same time, it also provides full-precision base models if you want to apply your own quantization strategy.
 
 <LinkList>
   ## Additional resources

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -14,9 +14,9 @@ const config: Config = {
 
   url: 'https://handbook.modular.com',
   baseUrl: '/',
-  trailingSlash: false,
+  trailingSlash: true,
 
-  onBrokenLinks: 'throw',
+  onBrokenLinks: 'ignore',
   onBrokenAnchors: 'throw',
 
   i18n: {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -16,7 +16,7 @@ const config: Config = {
   baseUrl: '/',
   trailingSlash: true,
 
-  onBrokenLinks: 'ignore',
+  onBrokenLinks: 'throw',
   onBrokenAnchors: 'throw',
 
   i18n: {


### PR DESCRIPTION
The real change here is `trailingSlash: true`, but doing that broke some links, so I had to fix those...

Docusaurus doesn’t serve a page like `llm-inference-basics.md` with a file named `llm-inference-basics.html`. It instead creates a directory with that name and generates an `index.html` file in it. That way the URLs never have to show the `.html` because a directory name always loads the `index.html` file by default.

But when `trailingSlash` is set false, a Markdown link to `/llm-inference-basics` technically creates a broken link because when taken literally, that’s not a filename that exists. That means the server actually responds with a 404 at first (CloudFront does at least) and then the Docusaurus client will try again by adding the slash. Then `/llm-inference-basics/` resolves by getting the `index.html` file in that directory. But this means that search crawlers and link crawlers might see only the 404 and never reach the real web page.

By adding `trailingSlash: true`, Docusaurus adds the trailing slash to all hyperlinks when it generates the HTML files, so the server responds with the correct `index.html` file the first time.

The consequence is:  With trailingSlash: true, Docusaurus treats each page as a directory (e.g. `/getting-started/bring-your-own-cloud/`), so relative links like `../inference-optimization/prefill-decode-disaggregation` resolve incorrectly to `/getting-started/inference-optimization/prefill-decode-disaggregation/` instead of `/inference-optimization/prefill-decode-disaggregation/`. That’s because the `..` travels only one step backward from the location of the `index.html` file, not the directory name that appears as a file in the URL. Thus, we must use root-relative URLs (always start with a slash).
