### PR TITLE
Add llms.txt generation for agent discoverability

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
 ---
-slug: /
 sidebar_label: Introduction
 sidebar_position: 0
 sidebar_class_name: hidden

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -84,12 +84,45 @@ const config: Config = {
         docsPath: '/',
         fullyQualifiedLinks: true,
         directive:
+          '> For the complete documentation index, see [llms.txt](/llms.txt).\n' +
           '> Markdown versions of all pages are available by appending .md to any URL.',
         htmlDirective:
-          'IMPORTANT: To view this page as Markdown, append `.md` to the URL.',
+          'IMPORTANT: To view this page as Markdown, append `.md` to the URL.\n' +
+          'For the complete documentation index, see <a href="/llms.txt">llms.txt</a>.',
         containerSelector: '.doc-actions',
         copyButtonText: 'Copy as Markdown',
         copiedButtonText: 'Copied!',
+      },
+    ],
+    [
+      'docusaurus-plugin-llms',
+      {
+        title: 'LLM Inference Handbook',
+        description:
+          'A practical handbook for engineers building, optimizing, scaling, and operating LLM inference systems in production.',
+        rootContent:
+          'Markdown versions of all pages are available by appending `.md` to any URL.\n\n' +
+          '- [LLM Inference Handbook](https://handbook.modular.com/index.md): A practical handbook for engineers building, optimizing, scaling, and operating LLM inference systems in production.\n',
+        generateLLMsFullTxt: false,
+        excludeImports: true,
+        docsDir: 'docs',
+        ignoreFiles: [
+          '**/LICENSE',
+          '**/README.md',
+          '**/img/**',
+          'adr/**',
+          'index.md',
+        ],
+        includeOrder: [
+          'getting-started/**/*',
+          'llm-inference-basics/**/*',
+          'inference-optimization/**/*',
+          'kernel-optimization/**/*',
+          'model-preparation/**/*',
+          'model-interaction/**/*',
+          'infrastructure-and-operations/**/*',
+        ],
+        includeUnmatchedLast: true,
       },
     ],
     [

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "autoprefixer": "^10.4.19",
     "clsx": "^2.1.0",
     "docusaurus-markdown-source-plugin": "github:modular/markdown_docusaurus_plugin#348c3b122df767a003daea07050f78bd56f636ff",
+    "docusaurus-plugin-llms": "^0.4.0",
     "docusaurus-plugin-sass": "^0.2.6",
     "postcss": "^8.4.39",
     "postcss-import": "^16.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       docusaurus-markdown-source-plugin:
         specifier: github:modular/markdown_docusaurus_plugin#348c3b122df767a003daea07050f78bd56f636ff
         version: https://codeload.github.com/modular/markdown_docusaurus_plugin/tar.gz/348c3b122df767a003daea07050f78bd56f636ff(@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(@swc/core@1.15.43)(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      docusaurus-plugin-llms:
+        specifier: ^0.4.0
+        version: 0.4.0(@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(@swc/core@1.15.43)(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))
       docusaurus-plugin-sass:
         specifier: ^0.2.6
         version: 0.2.6(@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(@swc/core@1.15.43)(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@rspack/core@1.7.12)(sass@1.62.1)(webpack@5.99.9(@swc/core@1.15.43))
@@ -85,7 +88,7 @@ importers:
         version: 1.62.1
       tailwindcss:
         specifier: ^3.4.4
-        version: 3.4.19
+        version: 3.4.19(yaml@2.9.0)
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: ^3.9.0
@@ -2407,6 +2410,9 @@ packages:
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -2926,6 +2932,12 @@ packages:
       '@docusaurus/core': ^3.0.0
       react: ^18.0.0
       react-dom: ^18.0.0
+
+  docusaurus-plugin-llms@0.4.0:
+    resolution: {integrity: sha512-jYlj2HJ5+gu7oJZuJ83Hk8KlB65YlZZ/7UpHXiL7Qr+qpNBkVocmt2Molc6F3HNr5RqcfhWD/98CvgyNztg/ow==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/core': ^3.0.0
 
   docusaurus-plugin-sass@0.2.6:
     resolution: {integrity: sha512-2hKQQDkrufMong9upKoG/kSHJhuwd+FA3iAe/qzS/BmWpbIpe7XKmq5wlz4J5CJaOPu4x+iDJbgAxZqcoQf0kg==}
@@ -4180,6 +4192,10 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -6023,6 +6039,11 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yocto-queue@1.2.1:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
@@ -9342,6 +9363,10 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.1.2:
+    dependencies:
+      balanced-match: 1.0.2
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -9843,6 +9868,13 @@ snapshots:
       fs-extra: 11.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  docusaurus-plugin-llms@0.4.0(@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(@swc/core@1.15.43)(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)):
+    dependencies:
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(@swc/core@1.15.43)(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      gray-matter: 4.0.3
+      minimatch: 9.0.9
+      yaml: 2.9.0
 
   docusaurus-plugin-sass@0.2.6(@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(@swc/core@1.15.43)(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@rspack/core@1.7.12)(sass@1.62.1)(webpack@5.99.9(@swc/core@1.15.43)):
     dependencies:
@@ -11467,6 +11499,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.2
+
   minimist@1.2.8: {}
 
   mrmime@2.0.1: {}
@@ -11860,12 +11896,13 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.6)
       postcss: 8.5.6
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.6
+      yaml: 2.9.0
 
   postcss-loader@7.3.4(postcss@8.5.6)(typescript@5.6.3)(webpack@5.99.9(@swc/core@1.15.43)):
     dependencies:
@@ -12989,7 +13026,7 @@ snapshots:
 
   tabbable@6.5.0: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(yaml@2.9.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -13008,7 +13045,7 @@ snapshots:
       postcss: 8.5.6
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.9.0)
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -13460,6 +13497,8 @@ snapshots:
       sax: 1.4.1
 
   yallist@3.1.1: {}
+
+  yaml@2.9.0: {}
 
   yocto-queue@1.2.1: {}
 

--- a/src/theme-modules.d.ts
+++ b/src/theme-modules.d.ts
@@ -1,0 +1,6 @@
+declare module '@theme/LlmsDirective' {
+  import type { ComponentType } from 'react';
+
+  const LlmsDirective: ComponentType;
+  export default LlmsDirective;
+}

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -1,0 +1,13 @@
+import React, { type ReactNode } from 'react';
+import Content from '@theme-original/DocItem/Content';
+import LlmsDirective from '@theme/LlmsDirective';
+import type { Props } from '@theme/DocItem/Content';
+
+export default function DocItemContentWrapper(props: Props): ReactNode {
+  return (
+    <>
+      <LlmsDirective />
+      <Content {...props} />
+    </>
+  );
+}


### PR DESCRIPTION
- Add docusaurus-plugin-llms to generate /llms.txt at build time
- Configure section-ordered index with .md links for AFDocs compliance
- Update markdown-source-plugin directives to point agents to llms.txt
- Swizzle DocItem/Content to render LlmsDirective on doc pages
- Rename introduction.md to index.md for consistency/predictability
- Ignore `index.md` from the generated llms.txt due to a bug: docusaurus-plugin-llms can't map a root docs/index.md page (served at /) to /index.md

Generated file shown here: https://pr-171-handbook.static.modular-staging.com/llms.txt