### PR TITLE
docs: Fix images

### DIFF
--- a/src/components/GPUExecutionVisualizer/styles.module.css
+++ b/src/components/GPUExecutionVisualizer/styles.module.css
@@ -146,12 +146,14 @@
   background: #faf5ff;
   transition:
     box-shadow 200ms ease,
-    border-color 200ms ease;
+    border-color 200ms ease,
+    background-color 200ms ease;
 }
 
 .smHighlight {
   border-color: #6d28d9;
-  box-shadow: none;
+  background: #f3e8ff;
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.35);
 }
 
 .smCompact {
@@ -188,12 +190,14 @@
   margin-bottom: 0.5rem;
   transition:
     box-shadow 200ms ease,
-    border-color 200ms ease;
+    border-color 200ms ease,
+    background-color 200ms ease;
 }
 
 .blockHighlight {
   border-color: var(--Elements-Neb-Ultra);
-  box-shadow: none;
+  background: var(--Elements-Neb-30-Alpha);
+  box-shadow: 0 0 0 3px rgba(99, 123, 255, 0.35);
 }
 
 .blockHeader {
@@ -213,7 +217,10 @@
   padding: 0.5rem 0.625rem;
   background: #f8faff;
   margin-bottom: 0.5rem;
-  transition: border-color 200ms ease;
+  transition:
+    box-shadow 200ms ease,
+    border-color 200ms ease,
+    background-color 200ms ease;
 }
 
 .blockCollapsedTitle {
@@ -238,12 +245,14 @@
   margin-bottom: 0.375rem;
   transition:
     box-shadow 200ms ease,
-    border-color 200ms ease;
+    border-color 200ms ease,
+    background-color 200ms ease;
 }
 
 .warpHighlight {
   border-color: var(--Elements-Neb-Ultra);
-  box-shadow: none;
+  background: var(--Elements-Neb-30-Alpha);
+  box-shadow: 0 0 0 3px rgba(99, 123, 255, 0.45);
 }
 
 .warpHeader {
@@ -274,7 +283,10 @@
   padding: 0.375rem 0.5rem;
   background: var(--Elements-Neb-20-Alpha);
   margin-bottom: 0.375rem;
-  transition: border-color 200ms ease;
+  transition:
+    box-shadow 200ms ease,
+    border-color 200ms ease,
+    background-color 200ms ease;
 }
 
 /* ── Thread grid: 32 cells in 16 columns ── */
@@ -631,4 +643,19 @@
 :global(html[data-theme='dark']) .hbmItem {
   background: rgba(251, 146, 60, 0.2);
   color: #fed7aa;
+}
+
+/* Dark-mode highlight states — must come after the dark background rules
+   above so the highlighted fill wins the cascade. */
+:global(html[data-theme='dark']) .smHighlight {
+  background: rgba(139, 92, 246, 0.28);
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.45);
+}
+:global(html[data-theme='dark']) .blockHighlight {
+  background: rgba(99, 123, 255, 0.2);
+  box-shadow: 0 0 0 3px rgba(99, 123, 255, 0.45);
+}
+:global(html[data-theme='dark']) .warpHighlight {
+  background: rgba(99, 123, 255, 0.28);
+  box-shadow: 0 0 0 3px rgba(99, 123, 255, 0.55);
 }

--- a/static/img/diagrams/llm-inference-flow-dark.svg
+++ b/static/img/diagrams/llm-inference-flow-dark.svg
@@ -21,6 +21,9 @@
   <line x1="565.0" y1="78.0" x2="577.0" y2="78.0" stroke="#637bff" stroke-width="1.5"/><polygon points="581.0,78.0 575.0,74.0 575.0,82.0" fill="#637bff"/>
   <line x1="621.0" y1="78.0" x2="633.0" y2="78.0" stroke="#637bff" stroke-width="1.5"/><polygon points="637.0,78.0 631.0,74.0 631.0,82.0" fill="#637bff"/>
   <line x1="677.0" y1="78.0" x2="689.0" y2="78.0" stroke="#637bff" stroke-width="1.5"/><polygon points="693.0,78.0 687.0,74.0 687.0,82.0" fill="#637bff"/>
+  <line x1="573.0" y1="78.0" x2="573.0" y2="93.0" stroke="#637bff" stroke-width="1.5"/><polygon points="573.0,97.0 569.0,91.0 577.0,91.0" fill="#637bff"/>
+  <line x1="629.0" y1="78.0" x2="629.0" y2="93.0" stroke="#637bff" stroke-width="1.5"/><polygon points="629.0,97.0 625.0,91.0 633.0,91.0" fill="#637bff"/>
+  <line x1="685.0" y1="78.0" x2="685.0" y2="93.0" stroke="#637bff" stroke-width="1.5"/><polygon points="685.0,97.0 681.0,91.0 689.0,91.0" fill="#637bff"/>
   <text x="629.0" y="108.0" font-family="Roboto Mono, Courier, monospace" font-size="11" fill="#9a9eaa" text-anchor="middle" font-weight="500" dominant-baseline="middle">Inter Token Latency (ITL)</text>
   <rect x="791.0" y="48.0" width="153.0" height="56.0" rx="4" fill="#1a3a5c" stroke="#637bff" stroke-width="2"/>
   <text x="867.5" y="76.0" font-family="Roboto Mono, Courier, monospace" font-size="14" fill="#ffffff" text-anchor="middle" font-weight="500" dominant-baseline="middle">Detokenization</text>

--- a/static/img/diagrams/llm-inference-flow.svg
+++ b/static/img/diagrams/llm-inference-flow.svg
@@ -21,6 +21,9 @@
   <line x1="565.0" y1="78.0" x2="577.0" y2="78.0" stroke="#637bff" stroke-width="1.5"/><polygon points="581.0,78.0 575.0,74.0 575.0,82.0" fill="#637bff"/>
   <line x1="621.0" y1="78.0" x2="633.0" y2="78.0" stroke="#637bff" stroke-width="1.5"/><polygon points="637.0,78.0 631.0,74.0 631.0,82.0" fill="#637bff"/>
   <line x1="677.0" y1="78.0" x2="689.0" y2="78.0" stroke="#637bff" stroke-width="1.5"/><polygon points="693.0,78.0 687.0,74.0 687.0,82.0" fill="#637bff"/>
+  <line x1="573.0" y1="78.0" x2="573.0" y2="93.0" stroke="#637bff" stroke-width="1.5"/><polygon points="573.0,97.0 569.0,91.0 577.0,91.0" fill="#637bff"/>
+  <line x1="629.0" y1="78.0" x2="629.0" y2="93.0" stroke="#637bff" stroke-width="1.5"/><polygon points="629.0,97.0 625.0,91.0 633.0,91.0" fill="#637bff"/>
+  <line x1="685.0" y1="78.0" x2="685.0" y2="93.0" stroke="#637bff" stroke-width="1.5"/><polygon points="685.0,97.0 681.0,91.0 689.0,91.0" fill="#637bff"/>
   <text x="629.0" y="108.0" font-family="Roboto Mono, Courier, monospace" font-size="11" fill="#676d71" text-anchor="middle" font-weight="500" dominant-baseline="middle">Inter Token Latency (ITL)</text>
   <rect x="791.0" y="48.0" width="153.0" height="56.0" rx="4" fill="#f0f2fd" stroke="#637bff" stroke-width="2"/>
   <text x="867.5" y="76.0" font-family="Roboto Mono, Courier, monospace" font-size="14" fill="#020c13" text-anchor="middle" font-weight="500" dominant-baseline="middle">Detokenization</text>

--- a/static/img/diagrams/llm-inference-ttft-latency-dark.svg
+++ b/static/img/diagrams/llm-inference-ttft-latency-dark.svg
@@ -44,6 +44,9 @@
   <line x1="565.0" y1="238.0" x2="577.0" y2="238.0" stroke="#637bff" stroke-width="1.5"/><polygon points="581.0,238.0 575.0,234.0 575.0,242.0" fill="#637bff"/>
   <line x1="621.0" y1="238.0" x2="633.0" y2="238.0" stroke="#637bff" stroke-width="1.5"/><polygon points="637.0,238.0 631.0,234.0 631.0,242.0" fill="#637bff"/>
   <line x1="677.0" y1="238.0" x2="689.0" y2="238.0" stroke="#637bff" stroke-width="1.5"/><polygon points="693.0,238.0 687.0,234.0 687.0,242.0" fill="#637bff"/>
+  <line x1="573.0" y1="238.0" x2="573.0" y2="253.0" stroke="#637bff" stroke-width="1.5"/><polygon points="573.0,257.0 569.0,251.0 577.0,251.0" fill="#637bff"/>
+  <line x1="629.0" y1="238.0" x2="629.0" y2="253.0" stroke="#637bff" stroke-width="1.5"/><polygon points="629.0,257.0 625.0,251.0 633.0,251.0" fill="#637bff"/>
+  <line x1="685.0" y1="238.0" x2="685.0" y2="253.0" stroke="#637bff" stroke-width="1.5"/><polygon points="685.0,257.0 681.0,251.0 689.0,251.0" fill="#637bff"/>
   <text x="629.0" y="268.0" font-family="Roboto Mono, Courier, monospace" font-size="11" fill="#9a9eaa" text-anchor="middle" font-weight="500" dominant-baseline="middle">Inter Token Latency (ITL)</text>
   <rect x="791.0" y="208.0" width="153.0" height="56.0" rx="4" fill="#1a3a5c" stroke="#637bff" stroke-width="2"/>
   <text x="867.5" y="236.0" font-family="Roboto Mono, Courier, monospace" font-size="14" fill="#ffffff" text-anchor="middle" font-weight="500" dominant-baseline="middle">Detokenization</text>

--- a/static/img/diagrams/llm-inference-ttft-latency.svg
+++ b/static/img/diagrams/llm-inference-ttft-latency.svg
@@ -44,6 +44,9 @@
   <line x1="565.0" y1="238.0" x2="577.0" y2="238.0" stroke="#637bff" stroke-width="1.5"/><polygon points="581.0,238.0 575.0,234.0 575.0,242.0" fill="#637bff"/>
   <line x1="621.0" y1="238.0" x2="633.0" y2="238.0" stroke="#637bff" stroke-width="1.5"/><polygon points="637.0,238.0 631.0,234.0 631.0,242.0" fill="#637bff"/>
   <line x1="677.0" y1="238.0" x2="689.0" y2="238.0" stroke="#637bff" stroke-width="1.5"/><polygon points="693.0,238.0 687.0,234.0 687.0,242.0" fill="#637bff"/>
+  <line x1="573.0" y1="238.0" x2="573.0" y2="253.0" stroke="#637bff" stroke-width="1.5"/><polygon points="573.0,257.0 569.0,251.0 577.0,251.0" fill="#637bff"/>
+  <line x1="629.0" y1="238.0" x2="629.0" y2="253.0" stroke="#637bff" stroke-width="1.5"/><polygon points="629.0,257.0 625.0,251.0 633.0,251.0" fill="#637bff"/>
+  <line x1="685.0" y1="238.0" x2="685.0" y2="253.0" stroke="#637bff" stroke-width="1.5"/><polygon points="685.0,257.0 681.0,251.0 689.0,251.0" fill="#637bff"/>
   <text x="629.0" y="268.0" font-family="Roboto Mono, Courier, monospace" font-size="11" fill="#676d71" text-anchor="middle" font-weight="500" dominant-baseline="middle">Inter Token Latency (ITL)</text>
   <rect x="791.0" y="208.0" width="153.0" height="56.0" rx="4" fill="#f0f2fd" stroke="#637bff" stroke-width="2"/>
   <text x="867.5" y="236.0" font-family="Roboto Mono, Courier, monospace" font-size="14" fill="#020c13" text-anchor="middle" font-weight="500" dominant-baseline="middle">Detokenization</text>

--- a/static/img/diagrams/llm-naming-dark.svg
+++ b/static/img/diagrams/llm-naming-dark.svg
@@ -7,12 +7,12 @@
   <rect x="28.0" y="110.0" width="170.0" height="30.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="113.0" y="125.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">Model Series</text>
   <text x="113.0" y="160.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="500" dominant-baseline="middle">Qwen3.5</text>
-  <line x1="113.0" y1="46.0" x2="113.0" y2="105.0" stroke="#637bff" stroke-width="1.5"/><polygon points="113.0,110.0 108.0,102.5 118.0,102.5" fill="#637bff"/>
+  <line x1="265.0" y1="42.0" x2="119.9" y2="103.1" stroke="#637bff" stroke-width="1.5"/><polygon points="113.0,106.0 108.0,98.5 118.0,98.5" fill="#637bff" transform="rotate(67.17 113.0 106.0)"/>
   <rect x="216.0" y="110.0" width="170.0" height="70.0" rx="4" fill="#20262c" stroke="#353d42" stroke-width="2"/>
   <rect x="216.0" y="110.0" width="170.0" height="30.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="301.0" y="125.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">Model Size</text>
   <text x="301.0" y="160.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="500" dominant-baseline="middle">35 Billion</text>
-  <line x1="301.0" y1="46.0" x2="301.0" y2="105.0" stroke="#637bff" stroke-width="1.5"/><polygon points="301.0,110.0 296.0,102.5 306.0,102.5" fill="#637bff"/>
+  <line x1="397.0" y1="42.0" x2="307.2" y2="101.8" stroke="#637bff" stroke-width="1.5"/><polygon points="301.0,106.0 296.0,98.5 306.0,98.5" fill="#637bff" transform="rotate(56.31 301.0 106.0)"/>
   <rect x="404.0" y="110.0" width="170.0" height="70.0" rx="4" fill="#20262c" stroke="#353d42" stroke-width="2"/>
   <rect x="404.0" y="110.0" width="170.0" height="30.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="489.0" y="125.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">Activation</text>
@@ -22,10 +22,10 @@
   <rect x="592.0" y="110.0" width="170.0" height="30.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="677.0" y="125.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">Quantization</text>
   <text x="677.0" y="160.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="500" dominant-baseline="middle">GPTQ Method</text>
-  <line x1="677.0" y1="46.0" x2="677.0" y2="105.0" stroke="#637bff" stroke-width="1.5"/><polygon points="677.0,110.0 672.0,102.5 682.0,102.5" fill="#637bff"/>
+  <line x1="601.0" y1="42.0" x2="671.3" y2="101.2" stroke="#637bff" stroke-width="1.5"/><polygon points="677.0,106.0 672.0,98.5 682.0,98.5" fill="#637bff" transform="rotate(-49.90 677.0 106.0)"/>
   <rect x="780.0" y="110.0" width="170.0" height="70.0" rx="4" fill="#20262c" stroke="#353d42" stroke-width="2"/>
   <rect x="780.0" y="110.0" width="170.0" height="30.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="865.0" y="125.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">Precision</text>
   <text x="865.0" y="160.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="500" dominant-baseline="middle">4-bit (Int4)</text>
-  <line x1="865.0" y1="46.0" x2="865.0" y2="105.0" stroke="#637bff" stroke-width="1.5"/><polygon points="865.0,110.0 860.0,102.5 870.0,102.5" fill="#637bff"/>
+  <line x1="733.0" y1="42.0" x2="858.3" y2="102.7" stroke="#637bff" stroke-width="1.5"/><polygon points="865.0,106.0 860.0,98.5 870.0,98.5" fill="#637bff" transform="rotate(-64.13 865.0 106.0)"/>
 </svg>

--- a/static/img/diagrams/llm-naming.svg
+++ b/static/img/diagrams/llm-naming.svg
@@ -7,12 +7,12 @@
   <rect x="28.0" y="110.0" width="170.0" height="30.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="113.0" y="125.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">Model Series</text>
   <text x="113.0" y="160.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#020c13" text-anchor="middle" font-weight="500" dominant-baseline="middle">Qwen3.5</text>
-  <line x1="113.0" y1="46.0" x2="113.0" y2="105.0" stroke="#637bff" stroke-width="1.5"/><polygon points="113.0,110.0 108.0,102.5 118.0,102.5" fill="#637bff"/>
+  <line x1="265.0" y1="42.0" x2="119.9" y2="103.1" stroke="#637bff" stroke-width="1.5"/><polygon points="113.0,106.0 108.0,98.5 118.0,98.5" fill="#637bff" transform="rotate(67.17 113.0 106.0)"/>
   <rect x="216.0" y="110.0" width="170.0" height="70.0" rx="4" fill="#f2f3f3" stroke="#d4dae4" stroke-width="2"/>
   <rect x="216.0" y="110.0" width="170.0" height="30.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="301.0" y="125.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">Model Size</text>
   <text x="301.0" y="160.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#020c13" text-anchor="middle" font-weight="500" dominant-baseline="middle">35 Billion</text>
-  <line x1="301.0" y1="46.0" x2="301.0" y2="105.0" stroke="#637bff" stroke-width="1.5"/><polygon points="301.0,110.0 296.0,102.5 306.0,102.5" fill="#637bff"/>
+  <line x1="397.0" y1="42.0" x2="307.2" y2="101.8" stroke="#637bff" stroke-width="1.5"/><polygon points="301.0,106.0 296.0,98.5 306.0,98.5" fill="#637bff" transform="rotate(56.31 301.0 106.0)"/>
   <rect x="404.0" y="110.0" width="170.0" height="70.0" rx="4" fill="#f2f3f3" stroke="#d4dae4" stroke-width="2"/>
   <rect x="404.0" y="110.0" width="170.0" height="30.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="489.0" y="125.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">Activation</text>
@@ -22,10 +22,10 @@
   <rect x="592.0" y="110.0" width="170.0" height="30.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="677.0" y="125.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">Quantization</text>
   <text x="677.0" y="160.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#020c13" text-anchor="middle" font-weight="500" dominant-baseline="middle">GPTQ Method</text>
-  <line x1="677.0" y1="46.0" x2="677.0" y2="105.0" stroke="#637bff" stroke-width="1.5"/><polygon points="677.0,110.0 672.0,102.5 682.0,102.5" fill="#637bff"/>
+  <line x1="601.0" y1="42.0" x2="671.3" y2="101.2" stroke="#637bff" stroke-width="1.5"/><polygon points="677.0,106.0 672.0,98.5 682.0,98.5" fill="#637bff" transform="rotate(-49.90 677.0 106.0)"/>
   <rect x="780.0" y="110.0" width="170.0" height="70.0" rx="4" fill="#f2f3f3" stroke="#d4dae4" stroke-width="2"/>
   <rect x="780.0" y="110.0" width="170.0" height="30.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="865.0" y="125.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">Precision</text>
   <text x="865.0" y="160.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#020c13" text-anchor="middle" font-weight="500" dominant-baseline="middle">4-bit (Int4)</text>
-  <line x1="865.0" y1="46.0" x2="865.0" y2="105.0" stroke="#637bff" stroke-width="1.5"/><polygon points="865.0,110.0 860.0,102.5 870.0,102.5" fill="#637bff"/>
+  <line x1="733.0" y1="42.0" x2="858.3" y2="102.7" stroke="#637bff" stroke-width="1.5"/><polygon points="865.0,106.0 860.0,98.5 870.0,98.5" fill="#637bff" transform="rotate(-64.13 865.0 106.0)"/>
 </svg>

--- a/static/img/diagrams/mcp-architecture-dark.svg
+++ b/static/img/diagrams/mcp-architecture-dark.svg
@@ -11,10 +11,10 @@
   <rect x="618.0" y="58.0" width="168.0" height="50.0" rx="4" fill="#20262c" stroke="#353d42" stroke-width="2"/>
   <text x="702.0" y="83.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="500" dominant-baseline="middle">Database</text>
   <line x1="210.0" y1="83.0" x2="324.0" y2="83.0" stroke="#637bff" stroke-width="2"/><polygon points="330.0,83.0 321.0,77.0 321.0,89.0" fill="#637bff"/>
-  <line x1="330.0" y1="83.0" x2="204.0" y2="83.0" stroke="#637bff" stroke-width="2"/><polygon points="210.0,83.0 201.0,77.0 201.0,89.0" fill="#637bff"/>
+  <line x1="330.0" y1="83.0" x2="216.0" y2="83.0" stroke="#637bff" stroke-width="2"/><polygon points="210.0,83.0 219.0,77.0 219.0,89.0" fill="#637bff"/>
   <text x="270.0" y="71.0" font-family="Roboto Mono, Courier, monospace" font-size="10" fill="#9a9eaa" text-anchor="middle" font-weight="500" dominant-baseline="middle">MCP</text>
   <line x1="498.0" y1="83.0" x2="612.0" y2="83.0" stroke="#637bff" stroke-width="2"/><polygon points="618.0,83.0 609.0,77.0 609.0,89.0" fill="#637bff"/>
-  <line x1="618.0" y1="83.0" x2="492.0" y2="83.0" stroke="#637bff" stroke-width="2"/><polygon points="498.0,83.0 489.0,77.0 489.0,89.0" fill="#637bff"/>
+  <line x1="618.0" y1="83.0" x2="504.0" y2="83.0" stroke="#637bff" stroke-width="2"/><polygon points="498.0,83.0 507.0,77.0 507.0,89.0" fill="#637bff"/>
   <rect x="42.0" y="132.0" width="168.0" height="50.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="126.0" y="157.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">MCP Client</text>
   <rect x="330.0" y="132.0" width="168.0" height="50.0" rx="4" fill="#1a3a5c" stroke="#637bff" stroke-width="2"/>
@@ -22,10 +22,10 @@
   <rect x="618.0" y="132.0" width="168.0" height="50.0" rx="4" fill="#20262c" stroke="#353d42" stroke-width="2"/>
   <text x="702.0" y="157.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="500" dominant-baseline="middle">Filesystem</text>
   <line x1="210.0" y1="157.0" x2="324.0" y2="157.0" stroke="#637bff" stroke-width="2"/><polygon points="330.0,157.0 321.0,151.0 321.0,163.0" fill="#637bff"/>
-  <line x1="330.0" y1="157.0" x2="204.0" y2="157.0" stroke="#637bff" stroke-width="2"/><polygon points="210.0,157.0 201.0,151.0 201.0,163.0" fill="#637bff"/>
+  <line x1="330.0" y1="157.0" x2="216.0" y2="157.0" stroke="#637bff" stroke-width="2"/><polygon points="210.0,157.0 219.0,151.0 219.0,163.0" fill="#637bff"/>
   <text x="270.0" y="145.0" font-family="Roboto Mono, Courier, monospace" font-size="10" fill="#9a9eaa" text-anchor="middle" font-weight="500" dominant-baseline="middle">MCP</text>
   <line x1="498.0" y1="157.0" x2="612.0" y2="157.0" stroke="#637bff" stroke-width="2"/><polygon points="618.0,157.0 609.0,151.0 609.0,163.0" fill="#637bff"/>
-  <line x1="618.0" y1="157.0" x2="492.0" y2="157.0" stroke="#637bff" stroke-width="2"/><polygon points="498.0,157.0 489.0,151.0 489.0,163.0" fill="#637bff"/>
+  <line x1="618.0" y1="157.0" x2="504.0" y2="157.0" stroke="#637bff" stroke-width="2"/><polygon points="498.0,157.0 507.0,151.0 507.0,163.0" fill="#637bff"/>
   <rect x="42.0" y="206.0" width="168.0" height="50.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="126.0" y="231.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">MCP Client</text>
   <rect x="330.0" y="206.0" width="168.0" height="50.0" rx="4" fill="#1a3a5c" stroke="#637bff" stroke-width="2"/>
@@ -33,8 +33,8 @@
   <rect x="618.0" y="206.0" width="168.0" height="50.0" rx="4" fill="#20262c" stroke="#353d42" stroke-width="2"/>
   <text x="702.0" y="231.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="500" dominant-baseline="middle">Cloud Service</text>
   <line x1="210.0" y1="231.0" x2="324.0" y2="231.0" stroke="#637bff" stroke-width="2"/><polygon points="330.0,231.0 321.0,225.0 321.0,237.0" fill="#637bff"/>
-  <line x1="330.0" y1="231.0" x2="204.0" y2="231.0" stroke="#637bff" stroke-width="2"/><polygon points="210.0,231.0 201.0,225.0 201.0,237.0" fill="#637bff"/>
+  <line x1="330.0" y1="231.0" x2="216.0" y2="231.0" stroke="#637bff" stroke-width="2"/><polygon points="210.0,231.0 219.0,225.0 219.0,237.0" fill="#637bff"/>
   <text x="270.0" y="219.0" font-family="Roboto Mono, Courier, monospace" font-size="10" fill="#9a9eaa" text-anchor="middle" font-weight="500" dominant-baseline="middle">MCP</text>
   <line x1="498.0" y1="231.0" x2="612.0" y2="231.0" stroke="#637bff" stroke-width="2"/><polygon points="618.0,231.0 609.0,225.0 609.0,237.0" fill="#637bff"/>
-  <line x1="618.0" y1="231.0" x2="492.0" y2="231.0" stroke="#637bff" stroke-width="2"/><polygon points="498.0,231.0 489.0,225.0 489.0,237.0" fill="#637bff"/>
+  <line x1="618.0" y1="231.0" x2="504.0" y2="231.0" stroke="#637bff" stroke-width="2"/><polygon points="498.0,231.0 507.0,225.0 507.0,237.0" fill="#637bff"/>
 </svg>

--- a/static/img/diagrams/mcp-architecture.svg
+++ b/static/img/diagrams/mcp-architecture.svg
@@ -11,10 +11,10 @@
   <rect x="618.0" y="58.0" width="168.0" height="50.0" rx="4" fill="#f2f3f3" stroke="#d4dae4" stroke-width="2"/>
   <text x="702.0" y="83.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#020c13" text-anchor="middle" font-weight="500" dominant-baseline="middle">Database</text>
   <line x1="210.0" y1="83.0" x2="324.0" y2="83.0" stroke="#637bff" stroke-width="2"/><polygon points="330.0,83.0 321.0,77.0 321.0,89.0" fill="#637bff"/>
-  <line x1="330.0" y1="83.0" x2="204.0" y2="83.0" stroke="#637bff" stroke-width="2"/><polygon points="210.0,83.0 201.0,77.0 201.0,89.0" fill="#637bff"/>
+  <line x1="330.0" y1="83.0" x2="216.0" y2="83.0" stroke="#637bff" stroke-width="2"/><polygon points="210.0,83.0 219.0,77.0 219.0,89.0" fill="#637bff"/>
   <text x="270.0" y="71.0" font-family="Roboto Mono, Courier, monospace" font-size="10" fill="#676d71" text-anchor="middle" font-weight="500" dominant-baseline="middle">MCP</text>
   <line x1="498.0" y1="83.0" x2="612.0" y2="83.0" stroke="#637bff" stroke-width="2"/><polygon points="618.0,83.0 609.0,77.0 609.0,89.0" fill="#637bff"/>
-  <line x1="618.0" y1="83.0" x2="492.0" y2="83.0" stroke="#637bff" stroke-width="2"/><polygon points="498.0,83.0 489.0,77.0 489.0,89.0" fill="#637bff"/>
+  <line x1="618.0" y1="83.0" x2="504.0" y2="83.0" stroke="#637bff" stroke-width="2"/><polygon points="498.0,83.0 507.0,77.0 507.0,89.0" fill="#637bff"/>
   <rect x="42.0" y="132.0" width="168.0" height="50.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="126.0" y="157.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">MCP Client</text>
   <rect x="330.0" y="132.0" width="168.0" height="50.0" rx="4" fill="#f0f2fd" stroke="#637bff" stroke-width="2"/>
@@ -22,10 +22,10 @@
   <rect x="618.0" y="132.0" width="168.0" height="50.0" rx="4" fill="#f2f3f3" stroke="#d4dae4" stroke-width="2"/>
   <text x="702.0" y="157.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#020c13" text-anchor="middle" font-weight="500" dominant-baseline="middle">Filesystem</text>
   <line x1="210.0" y1="157.0" x2="324.0" y2="157.0" stroke="#637bff" stroke-width="2"/><polygon points="330.0,157.0 321.0,151.0 321.0,163.0" fill="#637bff"/>
-  <line x1="330.0" y1="157.0" x2="204.0" y2="157.0" stroke="#637bff" stroke-width="2"/><polygon points="210.0,157.0 201.0,151.0 201.0,163.0" fill="#637bff"/>
+  <line x1="330.0" y1="157.0" x2="216.0" y2="157.0" stroke="#637bff" stroke-width="2"/><polygon points="210.0,157.0 219.0,151.0 219.0,163.0" fill="#637bff"/>
   <text x="270.0" y="145.0" font-family="Roboto Mono, Courier, monospace" font-size="10" fill="#676d71" text-anchor="middle" font-weight="500" dominant-baseline="middle">MCP</text>
   <line x1="498.0" y1="157.0" x2="612.0" y2="157.0" stroke="#637bff" stroke-width="2"/><polygon points="618.0,157.0 609.0,151.0 609.0,163.0" fill="#637bff"/>
-  <line x1="618.0" y1="157.0" x2="492.0" y2="157.0" stroke="#637bff" stroke-width="2"/><polygon points="498.0,157.0 489.0,151.0 489.0,163.0" fill="#637bff"/>
+  <line x1="618.0" y1="157.0" x2="504.0" y2="157.0" stroke="#637bff" stroke-width="2"/><polygon points="498.0,157.0 507.0,151.0 507.0,163.0" fill="#637bff"/>
   <rect x="42.0" y="206.0" width="168.0" height="50.0" rx="4" fill="#637bff" stroke="#637bff" stroke-width="2"/>
   <text x="126.0" y="231.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="600" dominant-baseline="middle">MCP Client</text>
   <rect x="330.0" y="206.0" width="168.0" height="50.0" rx="4" fill="#f0f2fd" stroke="#637bff" stroke-width="2"/>
@@ -33,8 +33,8 @@
   <rect x="618.0" y="206.0" width="168.0" height="50.0" rx="4" fill="#f2f3f3" stroke="#d4dae4" stroke-width="2"/>
   <text x="702.0" y="231.0" font-family="Roboto Mono, Courier, monospace" font-size="13" fill="#020c13" text-anchor="middle" font-weight="500" dominant-baseline="middle">Cloud Service</text>
   <line x1="210.0" y1="231.0" x2="324.0" y2="231.0" stroke="#637bff" stroke-width="2"/><polygon points="330.0,231.0 321.0,225.0 321.0,237.0" fill="#637bff"/>
-  <line x1="330.0" y1="231.0" x2="204.0" y2="231.0" stroke="#637bff" stroke-width="2"/><polygon points="210.0,231.0 201.0,225.0 201.0,237.0" fill="#637bff"/>
+  <line x1="330.0" y1="231.0" x2="216.0" y2="231.0" stroke="#637bff" stroke-width="2"/><polygon points="210.0,231.0 219.0,225.0 219.0,237.0" fill="#637bff"/>
   <text x="270.0" y="219.0" font-family="Roboto Mono, Courier, monospace" font-size="10" fill="#676d71" text-anchor="middle" font-weight="500" dominant-baseline="middle">MCP</text>
   <line x1="498.0" y1="231.0" x2="612.0" y2="231.0" stroke="#637bff" stroke-width="2"/><polygon points="618.0,231.0 609.0,225.0 609.0,237.0" fill="#637bff"/>
-  <line x1="618.0" y1="231.0" x2="492.0" y2="231.0" stroke="#637bff" stroke-width="2"/><polygon points="498.0,231.0 489.0,225.0 489.0,237.0" fill="#637bff"/>
+  <line x1="618.0" y1="231.0" x2="504.0" y2="231.0" stroke="#637bff" stroke-width="2"/><polygon points="498.0,231.0 507.0,225.0 507.0,237.0" fill="#637bff"/>
 </svg>


### PR DESCRIPTION
 - Improved GPU execution visualizer highlights.
 - Fixed LLM naming image arrows.
 - Fixed bidirectional arrowheads in MCP architecture diagrams.
 - Added ITL indicator arrows for every decode token gap.