### PR TITLE
docs: Fix language in openai-compatible api doc

### DIFF
--- a/docs/model-interaction/openai-compatible-api.md
+++ b/docs/model-interaction/openai-compatible-api.md
@@ -57,7 +57,7 @@ OpenAI-compatible APIs address these challenges by providing:
 
 Many
 [inference backends](/getting-started/choosing-the-right-inference-framework/)
-(e.g., vLLM and SGLang) and model serving frameworks (e.g., MAX) provide
+(e.g., vLLM, SGLang, and MAX) provide
 OpenAI-compatible endpoints out of the box. This makes it easier to switch
 between different models without changing client code.
 


### PR DESCRIPTION
I reckon the model serving framework here referred to BentoML, which was later replaced with MAX. Let's just put it together with vLLM and SGLang, like other places in the handbook.