### PR TITLE
docs: Fix format issues

### DIFF
--- a/docs/getting-started/choosing-the-right-gpu.md
+++ b/docs/getting-started/choosing-the-right-gpu.md
@@ -287,14 +287,14 @@ use shared and dedicated endpoints depending on your needs.
 Weight loading happens at service startup. Here is the specific pipeline:
 
 1. Model files are read from disk (SSD / network storage)
-    - Model checkpoint (e.g., `.safetensors`, `.bin`)
-    - Read via CPU
-    - Very slow compared to GPU memory
-    - Bandwidth: SSD at ~1–10 GB/s
+   - Model checkpoint (e.g., `.safetensors`, `.bin`)
+   - Read via CPU
+   - Very slow compared to GPU memory
+   - Bandwidth: SSD at ~1–10 GB/s
 2. CPU RAM staging
-    - Weights are temporarily placed in system memory
-    - Often deserialized or memory-mapped
-    - CPU RAM bandwidth: ~50–200 GB/s for typical configurations
+   - Weights are temporarily placed in system memory
+   - Often deserialized or memory-mapped
+   - CPU RAM bandwidth: ~50–200 GB/s for typical configurations
 3. Transferred to
    [GPU HBM](/kernel-optimization/gpu-architecture-fundamentals/#hbm-high-bandwidth-memory)
 4. Cached there for the lifetime of the serving process

--- a/docs/getting-started/serverless-vs-self-hosted-llm-inference.md
+++ b/docs/getting-started/serverless-vs-self-hosted-llm-inference.md
@@ -116,7 +116,7 @@ cheaper over time, thanks to:
   </figure>
 
 - GPU hardware is becoming more efficient and affordable.
-- Projects like vLLM and SGLang improve model inference efficiency.
+- Projects like vLLM, SGLang and MAX improve model inference efficiency.
 - Better-performing open-source models that require fewer resources with
   different optimization techniques.
 

--- a/docs/inference-optimization/speculative-decoding.md
+++ b/docs/inference-optimization/speculative-decoding.md
@@ -114,7 +114,9 @@ When evaluating speculative decoding, three metrics matter most:
   [Fast Inference from Transformers via Speculative Decoding](https://arxiv.org/pdf/2211.17192),
   you can calculate it with a theoretical formula:
 
-  $$ \tau = \frac{1 - \alpha^{\gamma+1}}{1 - \alpha} $$
+  $$
+  \tau = \frac{1 - \alpha^{\gamma+1}}{1 - \alpha}
+  $$
 
 ### How acceptance rate impacts performance
 

--- a/docs/kernel-optimization/flashattention.md
+++ b/docs/kernel-optimization/flashattention.md
@@ -45,8 +45,10 @@ tiling, see
 
 Standard attention calculates:
 
-<!-- rumdl-disable-next-line MD013 -->
-$$ \text{Attention}(Q, K, V) = \mathrm{softmax}\left(\frac{QK^T}{\sqrt{d_k}}\right)V $$
+$$
+\text{Attention}(Q, K, V)
+= \mathrm{softmax}\left(\frac{QK^T}{\sqrt{d_k}}\right)V
+$$
 
 The naive implementation follows these steps:
 

--- a/docs/kernel-optimization/kernel-optimization-for-llm-inference.md
+++ b/docs/kernel-optimization/kernel-optimization-for-llm-inference.md
@@ -49,16 +49,17 @@ depending on how much control you want over the GPU.
   - Custom CUDA kernels
   - Optimized attention implementations like FlashAttention
 
-    This gives you fine-grained control. You can design and tune memory access,
-    thread layout, and computation schedule from scratch. However, it’s also
-    hard as it requires deep knowledge of GPU architecture.
-    :::note
-    For Triton, you're still writing kernels, but the tile-based programming
-    model hides many of the low-level details: no manual warp management, no
-    explicit shared memory scheduling for common patterns. This makes Triton
-    easier than writing raw CUDA kernels. It also provides more control than
-    fully compiler-driven methods.
-    :::
+  This gives you fine-grained control. You can design and tune memory access,
+  thread layout, and computation schedule from scratch. However, it’s also
+  hard as it requires deep knowledge of GPU architecture.
+
+  :::note
+  For Triton, you're still writing kernels, but the tile-based programming
+  model hides many of the low-level details: no manual warp management, no
+  explicit shared memory scheduling for common patterns. This makes Triton
+  easier than writing raw CUDA kernels. It also provides more control than
+  fully compiler-driven methods.
+  :::
 
 - **Compiler-driven optimization**. You rely on compiler systems such as TVM or
   XLA to generate optimized kernels from a higher-level description of
@@ -67,11 +68,11 @@ depending on how much control you want over the GPU.
   - Reorder computation for better efficiency
   - Generate optimized kernels automatically
 
-    In this model, you describe what to compute, and the compiler determines how
-    to execute it efficiently for the target hardware backend. This
-    significantly lowers the barrier to entry. However, it offers less direct
-    control over low-level execution and may lag behind hand-written kernels
-    when supporting new model architectures or specialized computation patterns.
+  In this model, you describe what to compute, and the compiler determines how
+  to execute it efficiently for the target hardware backend. This
+  significantly lowers the barrier to entry. However, it offers less direct
+  control over low-level execution and may lag behind hand-written kernels
+  when supporting new model architectures or specialized computation patterns.
 
 ## What kernel optimization is not
 

--- a/docs/llm-inference-basics/how-does-llm-inference-work.md
+++ b/docs/llm-inference-basics/how-does-llm-inference-work.md
@@ -401,8 +401,8 @@ At a high level, LLM inference follows a simple loop:
 1. The input text is converted into tokens
 2. Tokens are processed in the prefill phase to build context and KV cache
 3. The model enters the decode phase. At each step:
-    - The model produces a probability distribution
-    - A sampling strategy selects the next token
+   - The model produces a probability distribution
+   - A sampling strategy selects the next token
 4. The process repeats until a stopping condition is met
 5. Tokens are converted back into readable text
 

--- a/docs/llm-inference-basics/llm-inference-metrics.md
+++ b/docs/llm-inference-basics/llm-inference-metrics.md
@@ -37,14 +37,18 @@ Key metrics to measure latency:
   first one. TTFT is excluded, since it measures only the steady generation
   phase:
 
-  $$ \text{Token Generation Time} = {\text{E2EL – TTFT}} $$
+  $$
+  \text{Token Generation Time} = {\text{E2EL – TTFT}}
+  $$
 
 - **Time per Output Token (TPOT)**: The average time gap between generating each
   subsequent token (excluding TTFT). A lower TPOT means the model can produce
   tokens faster, leading to higher tokens per second. TPOT is usually calculated
   as follows:
 
-  $$ \text{TPOT} = \frac{\text{E2EL – TTFT}}{\text{Total Output Tokens} - 1} $$
+  $$
+  \text{TPOT} = \frac{\text{E2EL – TTFT}}{\text{Total Output Tokens} - 1}
+  $$
 
   In streaming scenarios where users see text appear word-by-word (like
   ChatGPT's interface), TPOT determines how smooth the experience feels. The
@@ -56,20 +60,27 @@ Key metrics to measure latency:
   For a single request, the mean of all ITLs equals TPOT, which is why
   **the two are sometimes used interchangeably**:
 
-  <!-- rumdl-disable-next-line MD013 -->
-  $$ \text{Average ITL} = \text{TPOT} = \frac{\text{E2EL – TTFT}}{\text{Total Output Tokens} - 1} $$
+  $$
+  \text{Average ITL} = \text{TPOT}
+  = \frac{\text{E2EL – TTFT}}{\text{Total Output Tokens} - 1}
+  $$
 
   Across multiple requests, however, the difference comes down to how you
   average:
 
-  <!-- rumdl-disable-next-line MD013 -->
-  $$ \text{Average ITL} = \frac{\text{Sum of all ITLs across Requests}}{\text{Total Output Tokens across Requests}} $$
+  $$
+  \text{Average ITL}
+  = \frac{\text{Sum of all ITLs across Requests}}
+         {\text{Total Output Tokens across Requests}}
+  $$
 
   In this case, the average ITL is different from the average TPOT since the
   latter is usually calculated as follows:
 
-  <!-- rumdl-disable-next-line MD013 -->
-  $$ \text{Average TPOT} = \frac{\text{TPOT}_1 + \text{TPOT}_2 + \cdots + \text{TPOT}_N}{N} $$
+  $$
+  \text{Average TPOT}
+  = \frac{\text{TPOT}_1 + \text{TPOT}_2 + \cdots + \text{TPOT}_N}{N}
+  $$
 
   When reading benchmark results, always check how TPOT and ITL are defined.
   Different frameworks and papers may calculate and use the metrics differently,
@@ -164,11 +175,12 @@ There are two common ways to measure throughput:
 - **Tokens per Second (TPS)**: This metric provides a finer-grained view of
   throughput by measuring how many tokens are processed every second across all
   active requests. It comes in two forms:
+
   - **Input TPS**: How many input tokens the model processes per second.
   - **Output TPS**: How many output tokens the model generates per second.
 
-    Understanding both metrics helps you identify performance bottlenecks based
-    on the nature of your inference workload. For example:
+  Understanding both metrics helps you identify performance bottlenecks based
+  on the nature of your inference workload. For example:
 
   - A summarization request that includes long documents (e.g., 2,000-token
     inputs) cares more about input TPS.
@@ -176,19 +188,19 @@ There are two common ways to measure throughput:
     [prompts](/model-interaction/prompt-engineering/) (e.g., 20-token prompt →
     500-token response) depends heavily on output TPS.
 
-    When reviewing benchmarks or evaluating LLM performance, **always check
-    whether TPS metrics refer to input, output, or a combined view**. They
-    highlight different strengths and limitations depending on the use case.
+  When reviewing benchmarks or evaluating LLM performance, **always check
+  whether TPS metrics refer to input, output, or a combined view**. They
+  highlight different strengths and limitations depending on the use case.
 
-    Factors that impact TPS:
+  Factors that impact TPS:
 
   - Batch size (larger batches can increase TPS until saturation)
   - KV cache efficiency and memory usage
   - Prompt length and generation length
   - GPU memory bandwidth and compute utilization
 
-    These factors also mean TPS can be easy to misread since it can be gamed.
-    For example:
+  These factors also mean TPS can be easy to misread since it can be gamed.
+  For example:
 
   - A shorter prompt lowers TTFT, which cuts the amount of work each request
     requires. With less work per request, TPS looks higher than it really is.


### PR DESCRIPTION
- Removed some leading spaces. Some bullet points were not correctly rendered at the right level.
- Fixed math equation formats. Equations across the handbook were written with the $$ delimiters inline on a single line (Written on one line, it parses as inline math). The result is that equations render left-aligned at body text size rather than centered as display blocks. Move the $$ fences onto their own lines so the equations parse as display math (namely, equations can be centered)