### PR TITLE
add support for Mojo syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "postcss": "^8.4.39",
     "postcss-import": "^16.1.0",
     "prism-react-renderer": "^2.1.0",
+    "prismjs": "^1.29.0",
     "rc-tooltip": "^6.4.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       prism-react-renderer:
         specifier: ^2.1.0
         version: 2.4.1(react@18.3.1)
+      prismjs:
+        specifier: ^1.29.0
+        version: 1.30.0
       rc-tooltip:
         specifier: ^6.4.0
         version: 6.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -1,0 +1,13 @@
+import siteConfig from '@generated/docusaurus.config';
+export default function prismIncludeLanguages(PrismObject) {
+  const {
+    themeConfig: { prism },
+  } = siteConfig;
+  const { additionalLanguages } = prism;
+  globalThis.Prism = PrismObject;
+  additionalLanguages.forEach((lang) => {
+    require(`prismjs/components/prism-${lang}`);
+  });
+  require('./prism-mojo');
+  delete globalThis.Prism;
+}

--- a/src/theme/prism-mojo.js
+++ b/src/theme/prism-mojo.js
@@ -1,0 +1,76 @@
+// Took python definition and added some 🔥
+Prism.languages.mojo = {
+  comment: {
+    pattern: /(^|[^\\])#.*/,
+    lookbehind: true,
+    greedy: true,
+  },
+  'string-interpolation': {
+    pattern:
+      /(?:f|fr|rf)(?:("""|''')[\s\S]*?\1|("|')(?:\\.|(?!\2)[^\\\r\n])*\2)/i,
+    greedy: true,
+    inside: {
+      interpolation: {
+        // "{" <expression> <optional "!s", "!r", or "!a"> <optional ":" format specifier> "}"
+        pattern:
+          /((?:^|[^{])(?:\{\{)*)\{(?!\{)(?:[^{}]|\{(?!\{)(?:[^{}]|\{(?!\{)(?:[^{}])+\})+\})+\}/,
+        lookbehind: true,
+        inside: {
+          'format-spec': {
+            pattern: /(:)[^:(){}]+(?=\}$)/,
+            lookbehind: true,
+          },
+          'conversion-option': {
+            pattern: /![sra](?=[:}]$)/,
+            alias: 'punctuation',
+          },
+          rest: null,
+        },
+      },
+      string: /[\s\S]+/,
+    },
+  },
+  'triple-quoted-string': {
+    pattern: /(?:[rub]|br|rb)?("""|''')[\s\S]*?\1/i,
+    greedy: true,
+    alias: 'string',
+  },
+  string: {
+    pattern: /(?:[rub]|br|rb)?("|')(?:\\.|(?!\1)[^\\\r\n])*\1/i,
+    greedy: true,
+  },
+  function: {
+    pattern: /((?:^|\s)(def|fn)[ \t]+)[a-zA-Z_]\w*(?=\s*\()/g,
+    lookbehind: true,
+  },
+  'class-name': {
+    pattern: /(\b(class|struct)\s+)\w+/i,
+    lookbehind: true,
+  },
+  decorator: {
+    pattern: /(^[\t ]*)@\w+(?:\.\w+)*/m,
+    lookbehind: true,
+    alias: ['annotation', 'punctuation'],
+    inside: {
+      punctuation: /\./,
+    },
+  },
+  keyword:
+    /\b(?:_(?=\s*:)|mut|read|ref|out|deinit|inout|borrowed|owned|alias|comptime|fn|let|struct|trait|var|and|as|assert|async|await|break|case|class|continue|def|del|elif|else|except|exec|finally|for|from|global|if|import|in|is|lambda|match|nonlocal|not|or|pass|print|raise|return|try|while|with|yield)\b/,
+  builtin:
+    /\b(?:__import__|__mlir_attr|__mlir_op|__mlir_type|abs|all|any|apply|ascii|basestring|bin|bool|buffer|bytearray|bytes|callable|chr|classmethod|cmp|coerce|compile|complex|delattr|dict|dir|divmod|enumerate|eval|execfile|file|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|intern|isinstance|issubclass|iter|len|list|locals|long|map|max|memoryview|min|next|object|oct|open|ord|pow|property|range|raw_input|reduce|reload|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|unichr|unicode|vars|xrange|zip)\b/,
+  boolean: /\b(?:False|None|True)\b/,
+  // Added these because they're referenced in the mojo docs
+  'special-vars':
+    /\b(?:self|NotImplemented|Ellipsis|__debug__|__file__|__name__|__qualname__)\b/,
+  number:
+    /\b0(?:b(?:_?[01])+|o(?:_?[0-7])+|x(?:_?[a-f0-9])+)\b|(?:\b\d+(?:_\d+)*(?:\.(?:\d+(?:_\d+)*)?)?|\B\.\d+(?:_\d+)*)(?:e[+-]?\d+(?:_\d+)*)?j?(?!\w)/i,
+  operator: /[-+%=]=?|!=|:=|\*\*?=?|\/\/?=?|<[<=>]?|>[=>]?|[&|^~]/,
+  punctuation: /[{}[\];(),.:]/,
+};
+
+Prism.languages.mojo['string-interpolation'].inside[
+  'interpolation'
+].inside.rest = Prism.languages.mojo;
+
+Prism.languages.py = Prism.languages.mojo;


### PR DESCRIPTION
Copied the `prism-mojo.js` file from mojolang.org.